### PR TITLE
Mentor sponsor transfer

### DIFF
--- a/classes/prompt.js
+++ b/classes/prompt.js
@@ -1,4 +1,5 @@
-const { Message } = require("discord.js");
+const Discord = require("discord.js");
+const discordServices = require('../discord-services');
 
 /**
  * The Prompt class has usefull static functions to prompt the user for information.
@@ -16,7 +17,7 @@ class Prompt {
      */
     static async messagePrompt(prompt, responseType, channel, userID) {
         // send prompt
-        let promptMsg = await channel.send('<@' + userID + '> ' + prompt + responseType === 'number' ? ' Respond a number only!' : '');
+        let promptMsg = await channel.send('<@' + userID + '> ' + prompt + (responseType === 'number' ? ' Respond a number only!' : ''));
 
         let msgs = await channel.awaitMessages(message => message.author.id === userID, {max: 1});
 
@@ -43,6 +44,24 @@ class Prompt {
         if (isNan(number)) return this.numberPrompt(prompt, channel, userId);
         else return number;
 
+    }
+
+    /**
+     * Prompts the user to respond to a message with an emoji.
+     * @param {String} prompt - the text prompt to send to user
+     * @param {Discord.TextChannel} channel - the channel to send the prompt to
+     * @param {String} userID - the ID of the user to prompt
+     * @async
+     * @returns {Promise<Discord.MessageReaction>} - the message reaction
+     */
+    static async reactionPrompt(prompt, channel, userID) {
+        let reactionMsg = await channel.send('<@' + userID + '> ' + prompt + ' React to this message with the emoji.');
+
+        let reactions = await reactionMsg.awaitReactions((reaction, user) => !user.bot, {max: 1});
+
+        discordServices.deleteMessage(reactionMsg);
+
+        return reactions.first();
     }
 }
 

--- a/commands/a_utility/role-transfer.js
+++ b/commands/a_utility/role-transfer.js
@@ -1,0 +1,91 @@
+// Discord.js commando requirements
+const PermissionCommand = require('../../classes/permission-command');
+const discordServices = require('../../discord-services');
+const Discord = require('discord.js');
+const Prompt = require('../../classes/prompt');
+
+// Command export
+module.exports = class RoleTransfer extends PermissionCommand {
+    constructor(client) {
+        super(client, {
+            name: 'roletransfer',
+            group: 'a_utility',
+            memberName: 'transfer role',
+            description: 'Will let users transfer roles. Usefull for sponsor reps that are also mentors!',
+            guildOnly: true,
+        },
+        {
+            roleID: discordServices.staffRole,
+            roleMessage: 'Hey there, the command !roletransfer is only available to staff!',
+        });
+    }
+
+
+    /**
+     * 
+     * @param {Discord.Message} message - the command message
+     */
+    async runCommand (message) {
+
+        // the emoji for staff to add new transfers
+        let newTransferEmoji = '🆕';
+
+        /**
+         * @typedef Transfer
+         * @property {String} name - the transfer name
+         * @property {String} description - the transfer description
+         * @property {Discord.Role} role - the transfer role
+         */
+
+        /**
+         * The transfers on this role transfer card.
+         * @type {Discord.Collection<String, Transfer>}
+         */
+        let transfers = new Discord.Collection();
+
+        const cardEmbed = new Discord.MessageEmbed().setColor(discordServices.embedColor)
+            .setTitle('Role Transfer!')
+            .setDescription('React to the specified emoji to get the role, un-react to remove the role.');
+
+        let cardMsg = await message.channel.send(cardEmbed);
+        cardMsg.react(newTransferEmoji);
+
+        let filter = (reaction, user) => !user.bot && (transfers.has(reaction.emoji.name) || reaction.emoji.name === newTransferEmoji);
+        let reactionCollector = cardMsg.createReactionCollector(filter, {dispose: true});
+
+        reactionCollector.on('collect', async (reaction, user) => {
+            if (reaction.emoji.name === newTransferEmoji && discordServices.checkForRole(message.guild.member(user), discordServices.staffRole)) {
+                let newTransferMsg = await Prompt.messagePrompt('What new transfer do you want to add? Your response should have (in this order, not including <>): @role <transfer name> - <transfer description>',
+                                                                    'string', message.channel, user.id);
+                let role = newTransferMsg.mentions.roles.first();
+                let firstStop = newTransferMsg.cleanContent.indexOf('-');
+                let name = newTransferMsg.cleanContent.substring(0, firstStop);
+                let description = newTransferMsg.cleanContent.substring(firstStop + 1);
+
+                let roleReaction = await Prompt.reactionPrompt('What emoji to you want to use for this transfer?', message.channel, message.author.id);
+
+                transfers.set(roleReaction.emoji.name, {
+                    name: name,
+                    description: description,
+                    role: role,
+                });
+
+                reaction.message.edit(reaction.message.embeds[0].addField(name + ' -> ' + roleReaction.emoji.name, description));
+                reaction.message.react(roleReaction.emoji.name);
+                reaction.users.remove(user.id);
+            }
+
+            if (transfers.has(reaction.emoji.name)) {
+                discordServices.addRoleToMember(message.guild.member(user), transfers.get(reaction.emoji.name).role);
+            }
+        });
+
+        reactionCollector.on('remove', (reaction, user) => {
+            if (transfers.has(reaction.emoji.name)) {
+                discordServices.removeRolToMember(message.guild.member(user), transfers.get(reaction.emoji.name).role);
+            }
+        });
+
+    }
+
+}

--- a/commands/verification/verification.js
+++ b/commands/verification/verification.js
@@ -58,12 +58,12 @@ module.exports = class Verificaiton extends PermissionCommand {
                 discordServices.discordLog(message.guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and they are now a hacker!");
                 break;
             case firebaseServices.status.SPONSOR_SUCCESS:
-                embed.addField('You Have Been Verified!', 'Hi there sponsor, thank you very much for being part of HackCamp and for joining our discord!');
+                embed.addField('You Have Been Verified!', 'Hi there sponsor, thank you very much for being part of nwhacks 2021 and for joining our discord!');
                 discordServices.replaceRoleToMember(message.member, discordServices.guestRole, discordServices.sponsorRole);
                 discordServices.discordLog(message.guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and they are now a sponsor!");
                 break;
             case firebaseServices.status.MENTOR_SUCCESS:
-                embed.addField('You Have Been Verified!', 'Hi there mentor, thank you very much for being part of HackCamp and for joining our discord!');
+                embed.addField('You Have Been Verified!', 'Hi there mentor, thank you very much for being part of nwhacks 2021 and for joining our discord!');
                 discordServices.replaceRoleToMember(message.member, discordServices.guestRole, discordServices.mentorRole);
                 discordServices.discordLog(message.guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and he is now a mentor!");
                 break;


### PR DESCRIPTION
Created the role transfer command. This command has a bigger scope than before. Staff can select what roles to add to the transfer, so it can also be used with hackers and even staff!