### PR TITLE
reminds mentors of unanswered tickets

### DIFF
--- a/classes/cave.js
+++ b/classes/cave.js
@@ -31,6 +31,7 @@ class Cave {
       * @typedef Times
       * @property {Number} inactivePeriod - number of minutes a ticket channel will be inactive before bot starts to delete it
       * @property {Number} bufferTime - number of minutes the bot will wait for a response before deleting ticket
+      * @property {Number} reminderTime - number of minutes the bot will wait before reminding mentors of unaccepted tickets
       */
 
     /**
@@ -489,9 +490,10 @@ class Cave {
                         'All ticket channels older than this time will be deleted. Careful - this cannot be undone!', adminConsole, admin.id);
 
                     // delete all active tickets fitting the given age criteria
-                    this.tickets.forEach(async ticket => {
+                    this.tickets.forEach(async (ticket) => {
                         var timeNow = Date.now();
-                        if ((timeNow - ticket.category.createdTimestamp) > (age * 60 * 1000)) { // check if ticket is over the given number of minutes old
+                        // check if ticket is over the given number of minutes old
+                        if (ticket.category != null && ((timeNow - ticket.category.createdTimestamp) > (age * 60 * 1000))) { 
                             if (!ticket.category.deleted) {
                                 await ticket.category.children.forEach(async child => await discordServices.deleteChannel(child));
                                 await discordServices.deleteChannel(ticket.category);
@@ -526,7 +528,7 @@ class Cave {
                         if (exclude) { // check if user specified to exclude certain channels from being deleted
                             // start with ticketsToDelete being a Collection of all active tickets, and delete the excluded tickets from the 
                             // Collection as long as their CategoryChannels have not been deleted 
-                            ticketsToDelete = this.tickets;
+                            ticketsToDelete = new Map(this.tickets);
                             ticketMentions.forEach(ticketNumber => {
                                 // check if the number provided by the user is an active ticket and that this ticket's category is still there
                                 if (ticketsToDelete.has(ticketNumber) && !ticketsToDelete.get(ticketNumber).category.deleted) {
@@ -558,7 +560,7 @@ class Cave {
                     }
                 }
             } else if (reaction.emoji.name === Array.from(this.adminEmojis.keys())[2]) { // check if Admin selected to include/exclude tickets from garbage collection
-                console.log(this.tickets.keys());
+                
                 var response = await Prompt.messagePrompt('**In one message separated by spaces**, ' +
                     'type whether you want to "include" or "exclude" tickets along with the ticket numbers to operate on.', 'string', adminConsole, admin.id, 30);
                 if (response != null) {

--- a/classes/ticket.js
+++ b/classes/ticket.js
@@ -159,7 +159,7 @@ class Ticket {
             type: 'category',
             permissionOverwrites: [
                 {
-                    id: discordServices.everyoneRole,
+                    id: discordServices.roleIDs.everyoneRole,
                     deny: ['VIEW_CHANNEL'],
                 }
             ]
@@ -189,6 +189,11 @@ class Ticket {
 
         // reaction collector that listens for the emojis that trigger actions
         const ticketCollector = this.ticketMsg.createReactionCollector((reaction, user) => !user.bot && ticketEmojis.has(reaction.emoji.name));
+
+        // if ticket has not been accepted after the specified time, it will send a reminder to the incoming tickets channel tagging all mentors
+        var timeout = setTimeout(() => {
+            this.cave.privateChannels.incomingTickets.send('Hello <@&' + discordServices.roleIDs.mentorRole + '> ticket number ' + this.ticketNumber + ' still needs help!');
+        }, this.cave.caveOptions.times.reminderTime * 60 * 1000);
 
         // let user know that ticket was submitted and give option to remove ticket
         let removeTicketEmoji = '⚔️';
@@ -230,6 +235,7 @@ class Ticket {
                 this.ticketMsg.edit(this.ticketMsg.embeds[0].addField('More hands on deck!', '<@' + helper.id + '> Joined the ticket!'));
                 this.openTicketEmbedMsg.edit(this.openTicketEmbedMsg.embeds[0].addField('More hands on deck!', '<@' + helper.id + '> Joined the ticket!'));
             } else {
+                clearTimeout(timeout);
                 // edit incoming ticket with mentor information
                 this.ticketMsg.edit(this.ticketMsg.embeds[0].addField('This ticket is being handled!', '<@' + helper.id + '> Is helping this team!')
                     .addField('Still want to help?', 'Click the ' + this.caveEmojis.joinTicketEmoji.toString() + ' emoji to join the ticket!')

--- a/commands/a_start_commands/start-mentor-room.js
+++ b/commands/a_start_commands/start-mentor-room.js
@@ -30,7 +30,7 @@ module.exports = class StartMentors extends PermissionCommand {
      */
     async runCommand(message) {
         try {
-            var emojis = new Collection(); //collection to keep the names of the emojis used so far, used to check for duplicates
+            var emojis = new Discord.Collection(); //collection to keep the names of the emojis used so far, used to check for duplicates
 
             //ask user for each emoji
             let joinTicketEmoji = await checkForDuplicateEmojis('What is the join ticket emoji?');
@@ -70,6 +70,8 @@ module.exports = class StartMentors extends PermissionCommand {
                     inactivePeriod: await Prompt.numberPrompt('How long, in minutes, does a ticket need to be inactive for before asking to delete it?',
                         message.channel, message.author.id),
                     bufferTime: await Prompt.numberPrompt('How long, in minutes, will the bot wait for a response to its request to delete a ticket?',
+                        message.channel, message.author.id),
+                    reminderTime: await Prompt.numberPrompt('How long, in minutes, shall a ticket go unaccepted before the bot sends a reminder to all mentors?',
                         message.channel, message.author.id),
                 }
             });

--- a/discord-services.js
+++ b/discord-services.js
@@ -92,7 +92,7 @@ module.exports.channelIDs = {
     /**
      * The admin console where admins can run commands.
      */
-    adminConsolChannel : '748955441484005488',
+    adminConsoleChannel : '803242206814011433',
 
     /**
      * The channel where the bot will log things.
@@ -296,7 +296,7 @@ module.exports.replyAndDelete = replyAndDelete;
  * @returns {Boolean}
  */
 function isAdminConsole(channel) {
-    return channel.id === this.channelIDs.adminConsolChannel;
+    return channel.id === this.channelIDs.adminConsoleChannel;
 }
 module.exports.isAdminConsole = isAdminConsole;
 


### PR DESCRIPTION
When creating the mentor cave, user can define a time after which tickets will "timeout" and send a message in the incoming tickets channel mentioning the Mentor role reminding them to take the ticket if possible. This will only be done once.

Also some bug fixes:
1. ticketsToDelete is now a clone of the cave's collection of tickets instead of passing it by reference.
2. Fixed spelling of "adminConsoleChannel" so that it is consistent.
3. When force deleting all ticket channels, there is now a check for whether the ticket has been accepted; previously createdTimeStamp threw an error when called on a ticket that never had a category to begin with.
4. Other minor bug fixes in terms of incorrect function/property references.

