### PR TITLE
Cmd f verifications

### DIFF
--- a/classes/activity.js
+++ b/classes/activity.js
@@ -148,13 +148,13 @@ class Activity {
         return this.guild.channels.create(this.name, {
             type: 'category',
             position: position >= 0 ? position : 0,
-            permissionOverwrites: discordServices.roleIDs?.attendeeRole ? [ // only lock the activity if the attendance role is in use
+            permissionOverwrites: discordServices.roleIDs?.memberRole ? [ // only lock the activity if the attendance role is in use
                 {
                     id: discordServices.roleIDs.everyoneRole,
                     deny: ['VIEW_CHANNEL']
                 },
                 {
-                    id: discordServices.roleIDs.attendeeRole,
+                    id: discordServices.roleIDs.memberRole,
                     allow: ['VIEW_CHANNEL']
                 },
                 {
@@ -317,7 +317,7 @@ class Activity {
      */
     async makeWorkshop() {
         // update the voice channel permission to no speaking for attendees
-        this.generalVoice.updateOverwrite(discordServices.roleIDs.hackerRole, {
+        this.generalVoice.updateOverwrite(discordServices.roleIDs.memberRole, {
             SPEAK: false,
         });
         this.generalVoice.updateOverwrite(discordServices.roleIDs.staffRole, {

--- a/classes/activity.js
+++ b/classes/activity.js
@@ -227,7 +227,7 @@ class Activity {
             }, 
             [
                 {
-                    roleID: discordServices.roleIDs.hackerRole,
+                    roleID: discordServices.roleIDs.memberRole,
                     permissions: {VIEW_CHANNEL: isPrivate ? false : true, USE_VAD: true, SPEAK: true},
                 },
             ]);
@@ -276,7 +276,7 @@ class Activity {
         this.addChannel('🎮' + 'game-codes', {
             type: 'text',
             topic: 'This channel is only intended to send game codes for others to join!',
-        }, [{roleID: discordServices.roleIDs.hackerRole, permissions: {VIEW_CHANNEL: false}}]);
+        }, [{roleID: discordServices.roleIDs.attendeeRole, permissions: {VIEW_CHANNEL: false}}]);
 
         this.addVoiceChannels(numOfChannels, true, 12);
 

--- a/classes/prompt.js
+++ b/classes/prompt.js
@@ -20,7 +20,7 @@ class Prompt {
      * @param {String} responseType - the type of response, one of string, number, boolean, mention
      * @param {Number} time - the time in seconds to wait for the response, if 0 then wait forever
      * @returns {Promise<Message>} - the message response to the prompt or false if it timed out!
-     * @throws Will throw an error if the user cancels the Prompt or it times out.
+     * @throws Will throw an error if the user cancels the Prompt or it times out. Name: Cancel or Timeout
      * @async
      */
     static async messagePrompt({prompt, channel, userId}, responseType, time = 0) {
@@ -33,22 +33,27 @@ class Prompt {
 
         try {
             var msgs = await channel.awaitMessages(message => message.author.id === userId, {max: 1, time: time == 0 ? null : time * 1000, errors: ['time']});
-            let msg = msgs.first();
-
-            discordServices.deleteMessage(promptMsg);
-            if (msg.channel.type != 'dm') discordServices.deleteMessage(msg);
-
-            // check if they responded with cancel
-            if (msg.content.toLowerCase() === 'cancel') {
-                throw new Error("The prompt has been canceled.");
-            }
-
-            return msg;
         } catch (error) {
             channel.send('<@' + userId + '> Time is up, please try again once you are ready, we recommend you write the text, then react, then send!').then(msg => msg.delete({timeout: 10000}));
             discordServices.deleteMessage(promptMsg);
-            throw new Error('Prompt timed out.');
+            let timeoutError = new Error('Prompt timed out.');
+            timeoutError.name = 'Timeout'
+            throw timeoutError;
         }
+
+        let msg = msgs.first();
+
+        discordServices.deleteMessage(promptMsg);
+        if (msg.channel.type != 'dm') discordServices.deleteMessage(msg);
+
+        // check if they responded with cancel
+        if (msg.content.toLowerCase() === 'cancel') {
+            let cancelError = new Error("The prompt has been canceled.");
+            cancelError.name = 'Cancel'
+            throw cancelError;
+        }
+
+        return msg;
     }
 
 
@@ -115,7 +120,7 @@ class Prompt {
      * Prompt the user for a channel mention.
      * @param {PromptInfo} promptInfo - the common data, prompt, channel, userId
      * @async
-     * @returns {Promise<Collection<TextChannel>>} - the text channels prompted
+     * @returns {Promise<Collection<String, TextChannel>>} - the text channels prompted <ChannelId, TextChannel>
      * @throws Will throw an error if the user cancels the Prompt or it times out.
      */
     static async channelPrompt({prompt, channel, userId}) {
@@ -133,7 +138,7 @@ class Prompt {
      * Prompt the user for a role mention.
      * @param {PromptInfo} promptInfo - the common data, prompt, channel, userId
      * @async
-     * @returns {Promise<Collection<Role>>} - the roles prompted
+     * @returns {Promise<Collection<String, Role>>} - the roles prompted <RoleId, Role>
      * @throws Will throw an error if the user cancels the Prompt or it times out.
      */
     static async rolePrompt({prompt, channel, userId}) {
@@ -150,7 +155,7 @@ class Prompt {
      * Prompt the user for a member mention.
      * @param {PromptInfo} promptInfo - the common data, prompt, channel, userId
      * @async
-     * @returns {Promise<Collection<GuildMember>>} - the members prompted
+     * @returns {Promise<Collection<String, GuildMember>>} - the members prompted <MemberId, GuildMember>
      * @throws Will throw an error if the user cancels the Prompt or it times out.
      */
     static async memberPrompt({prompt, channel, userId}) {

--- a/classes/verification.js
+++ b/classes/verification.js
@@ -79,7 +79,29 @@ class Verification {
             });
             discordServices.discordLog(guild, `VERIFY ERROR : <@${member.id}> Verified email: ${email} had types available, but I could not find them on the botGuild!`);
         }
-    }   
+    }
+
+
+    /**
+     * Will attend the user and give it the attendee role.
+     * @param {GuildMember} member 
+     */
+    async static attend(member) {
+        try {
+            // wait for attend to end, then give role
+            await firebaseServices.attend(member.id);
+            discordServices.addRoleToMember(member, discordServices.roleIDs.attendeeRole);
+            discordServices.sendEmbedToMember(member, {
+                title: 'Attendance Success',
+                description: 'You have been marked as attending, thank you and good luck!',
+                color: discordServices.colors.specialDMEmbedColor,
+            });
+            discordServices.discordLog(member.guild, `ATTEND SUCCESS : <@${member.id}> has been marked as attending!`);
+        } catch (error) {
+            // email was not found, let admins know!
+            discordServices.discordLog(member.guild, `ATTEND WARNING : <@${member.id}> tried to attend but I could not find his discord ID! He might be an impostor!!!`);
+        }
+    }
 
 }
 module.exports = Verification;

--- a/classes/verification.js
+++ b/classes/verification.js
@@ -15,7 +15,7 @@ class Verification {
      * @async
      * @static
      */
-    async static verify(member, email, guild) {
+    static async verify(member, email, guild) {
         // make email lowercase
         email = email.toLowerCase();
 
@@ -86,7 +86,7 @@ class Verification {
      * Will attend the user and give it the attendee role.
      * @param {GuildMember} member 
      */
-    async static attend(member) {
+    static async attend(member) {
         try {
             // wait for attend to end, then give role
             await firebaseServices.attend(member.id);

--- a/classes/verification.js
+++ b/classes/verification.js
@@ -1,0 +1,85 @@
+const { GuildMember, Guild } = require('discord.js');
+const discordServices = require('../discord-services');
+const firebaseServices = require('../firebase-services/firebase-services');
+
+/**
+ * @class Verification
+ */
+class Verification {
+
+    /**
+     * Verifies a guild member into a guild.
+     * @param {GuildMember} member - member to verify
+     * @param {String} email - email to verify with
+     * @param {Guild} guild
+     * @async
+     * @static
+     */
+    async static verify(member, email, guild) {
+        // make email lowercase
+        email = email.toLowerCase();
+
+        // regex to validate email
+        const re = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+
+        // let user know he has used the command incorrectly and exit
+        if (email === '' || !re.test(email)) {
+            discordServices.sendMessageToMember(member, 'The email you sent me is not valid, please try again!', true);
+            return;
+        }
+
+        // try to get member types, error will mean no email was found
+        try {
+            var types = await firebaseServices.verify(email, member.id);
+        } catch (error) {
+            discordServices.sendEmbedToMember(member, {
+                title: 'Verification Failure',
+                description: 'The email provided was not found! If you need assistance ask an admin for help!',
+            });
+            discordServices.discordLog(guild, `VERIFY FAILURE : <@${member.id}> Verified email: ${email} but was a failure, I could not find that email!`);
+            return;
+        }
+
+        // check for types, if no types it means they are already verified with those types
+        if (types.length === 0) {
+            discordServices.sendEmbedToMember(member, {
+                title: 'Verification Warning',
+                description: 'We found your email, but you are already verified! If this is not the case let an admin know!',
+                color: '#fc1403',
+            });
+            discordServices.discordLog(guild, `VERIFY WARNING : <@${member.id}> Verified email: ${email} but he was already verified for all types!`);
+            return;
+        }
+
+        let correctTypes = [];
+        
+        // check for correct types with botGuild verification info and give the roles
+        types.forEach((type, index, array) => {
+            if (discordServices.verificationRoles.has(type)) {
+                discordServices.addRoleToMember(member, discordServices.verificationRoles.get(type));
+                correctTypes.push(type);
+            }
+        });
+
+        // extra check to see if types were found, give stamp role if available and let user know of success
+        if (correctTypes.length > 0) {
+            discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.memberRole);
+            if (discordServices.stampRoles.has(0)) discordServices.addRoleToMember(member, discordServices.stampRoles.get(0));
+            discordServices.sendEmbedToMember(member, {
+                title: 'cmd-f 2021 Verification Success',
+                description: `You have been verified as a ${correctTypes.join()}, good luck and have fun!`,
+                color: discordServices.colors.specialDMEmbedColor,
+            });
+            discordServices.discordLog(guild, `VERIFY SUCCESS : <@${member.id}> Verified email: ${email} successfully as ${correctTypes.join()}`);
+        } else {
+            discordServices.sendEmbedToMember(member, {
+                title: 'Verification Error',
+                description: 'There has been an error, contact an admin ASAP!',
+                color: '#fc1403',
+            });
+            discordServices.discordLog(guild, `VERIFY ERROR : <@${member.id}> Verified email: ${email} had types available, but I could not find them on the botGuild!`);
+        }
+    }   
+
+}
+module.exports = Verification;

--- a/classes/verification.js
+++ b/classes/verification.js
@@ -14,18 +14,11 @@ class Verification {
      * @param {Guild} guild
      * @async
      * @static
+     * @throws Error if email is not valid!
      */
     static async verify(member, email, guild) {
-        // make email lowercase
-        email = email.toLowerCase();
-
-        // regex to validate email
-        const re = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
-
-        // let user know he has used the command incorrectly and exit
-        if (email === '' || !re.test(email)) {
-            discordServices.sendMessageToMember(member, 'The email you sent me is not valid, please try again!', true);
-            return;
+        if (!discordServices.validateEmail(email)) {
+            throw new Error('Email is not valid!!');
         }
 
         // try to get member types, error will mean no email was found

--- a/commands/a_activity/archive.js
+++ b/commands/a_activity/archive.js
@@ -33,13 +33,13 @@ module.exports = class InitAmongUs extends ActivityCommand {
             archiveCategory = await message.guild.channels.create('💼archive', {
                 type: 'category', 
                 position: position + 1,
-                permissionOverwrites: discordServices.roleIDs?.attendeeRole ? [
+                permissionOverwrites: discordServices.roleIDs?.memberRole ? [
                     {
                         id: discordServices.roleIDs.everyoneRole,
                         deny: ['VIEW_CHANNEL'],
                     },
                     {
-                        id: discordServices.roleIDs.attendeeRole,
+                        id: discordServices.roleIDs.memberRole,
                         allow: ['VIEW_CHANNEL'],
                     },
                     {

--- a/commands/a_activity/discord-contests.js
+++ b/commands/a_activity/discord-contests.js
@@ -175,10 +175,13 @@ module.exports = class DiscordContests extends PermissionCommand {
                     collector.on('collect', m => {
                         if (!needAllAnswers) {
                             // for questions that have numbers as answers, the answer has to match at least one of the correct answers exactly
-                            if (!isNaN(answers[0]) && answers.some(correctAnswer => m.content == correctAnswer)) {
-                                message.channel.send("Congrats <@" + m.author.id + "> for getting the correct answer! The answer key is " + answers.join(' or ') + ".");
-                                winners.push(m.author.id);
-                                collector.stop();
+                            if (!isNaN(answers[0])) {
+                                console.log(m.content);
+                                if (answers.some(correctAnswer => m.content === correctAnswer)) {
+                                    message.channel.send("Congrats <@" + m.author.id + "> for getting the correct answer! The answer key is " + answers.join(' or ') + ".");
+                                    winners.push(m.author.id);
+                                    collector.stop();
+                                }
                             } else if (answers.some(correctAnswer => m.content.toLowerCase().includes(correctAnswer.toLowerCase()))) {
                                 //for most questions, an answer that contains at least once item of the answer array is correct
                                 message.channel.send("Congrats <@" + m.author.id + "> for getting the correct answer! The answer key is " + answers.join(' or ') + ".");

--- a/commands/a_activity/hide-unhide.js
+++ b/commands/a_activity/hide-unhide.js
@@ -73,12 +73,12 @@ module.exports = class HideUnhide extends Command {
         // update overwrites
         if (toHide) {
             // category = await category.setName('HIDDEN-' + category.name);
-            category.updateOverwrite(discordServices.roleIDs.attendeeRole, {VIEW_CHANNEL: false});
+            category.updateOverwrite(discordServices.roleIDs.memberRole, {VIEW_CHANNEL: false});
             category.updateOverwrite(discordServices.roleIDs.mentorRole, {VIEW_CHANNEL: false});
             category.updateOverwrite(discordServices.roleIDs.sponsorRole, {VIEW_CHANNEL: false});
         } else {
             // category = await category.setName(category.name.replace('HIDDEN-', ''));
-            category.updateOverwrite(discordServices.roleIDs.attendeeRole, {VIEW_CHANNEL: true});
+            category.updateOverwrite(discordServices.roleIDs.memberRole, {VIEW_CHANNEL: true});
             category.updateOverwrite(discordServices.roleIDs.mentorRole, {VIEW_CHANNEL: true});
             category.updateOverwrite(discordServices.roleIDs.sponsorRole, {VIEW_CHANNEL: true});
         }

--- a/commands/verification/attend.js
+++ b/commands/verification/attend.js
@@ -23,7 +23,7 @@ module.exports = class Attend extends PermissionCommand {
                 {
                     key: 'guildId',
                     prompt: 'Please provide the server ID, ask admins for it!',
-                    type: 'number',
+                    type: 'integer',
                 },
             ],
         },

--- a/commands/verification/attend.js
+++ b/commands/verification/attend.js
@@ -15,12 +15,6 @@ module.exports = class Attend extends PermissionCommand {
             description: 'Will mark a hacker as attending and upgrade role to Attendee. Can only be called once!',
             args: [
                 {
-                    key: 'email',
-                    prompt: 'Please provide your email address',
-                    type: 'string',
-                    default: '',
-                },
-                {
                     key: 'guildId',
                     prompt: 'Please provide the server ID, ask admins for it!',
                     type: 'integer',
@@ -35,27 +29,15 @@ module.exports = class Attend extends PermissionCommand {
     /**
      * 
      * @param {Discord.Message} message 
-     * @param {String} param1 
+     * @param {String} guildId 
      */
-    async runCommand(message, { email, guildId }) {
+    async runCommand(message, { guildId }) {
         // check if the user needs to attend, else warn and return
         if (discordServices.checkForRole(message.author, discordServices.roleIDs.attendeeRole)) {
             discordServices.sendEmbedToMember(message.author, {
                 title: 'Attend Error',
                 description: 'You do not need to attend! Happy hacking!!!'
             }, true);
-            return;
-        }
-
-        // make email lowercase
-        email = email.toLowerCase();
-
-        // regex to validate email
-        const re = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
-
-        // let user know he has used the command incorrectly and exit
-        if (email === '' || !re.test(email)) {
-            discordServices.sendMessageToMember(message.author, 'You have used the verify command incorrectly! \nPlease write a valid email after the command like this: !verify email@gmail.com');
             return;
         }
 

--- a/commands/verification/manual-verify.js
+++ b/commands/verification/manual-verify.js
@@ -55,9 +55,18 @@ module.exports = class ManualVerify extends PermissionCommand {
             types = types.filter((type, index, array) => discordServices.verificationRoles.has(type)); // filter types for those valid
 
             let email = (await Prompt.messagePrompt({ prompt: 'What is their email?', channel, userId }, 'string', 20)).content;
+            // validate the email
+            if(!discordServices.validateEmail(email)) {
+                discordServices.sendMsgToChannel(channel, userId, 'The email is not valid!', 5);
+                return;
+            }
             
             firebaseServices.addUserData(email, member, types);
-            await Verification.verify(member, email, message.guild);
+            try {
+                await Verification.verify(member, email, guild);
+            } catch (error) {
+                discordServices.sendMsgToChannel(channel, userId, 'Email provided is not valid!', 5);
+            }
             
             message.channel.send('Verification complete!').then(msg => msg.delete({ timeout: 3000 }));
             

--- a/commands/verification/start-attend.js
+++ b/commands/verification/start-attend.js
@@ -2,6 +2,7 @@ const PermissionCommand = require('../../classes/permission-command');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const Prompt = require('../../classes/prompt');
+const Verification = require('../../classes/verification');
 
 /**
  * StartAttend makes a new channel called #attend, or uses an existing channel of the user's choice, as the channel where the attend
@@ -90,13 +91,8 @@ module.exports = class StartAttend extends PermissionCommand {
             let member = message.guild.member(user.id);
 
             // check if user needs to attend
-            if (discordServices.checkForRole(member, discordServices.roleIDs.hackerRole) && 
-                !discordServices.checkForRole(member, discordServices.roleIDs.attendeeRole)) {
-                    discordServices.addRoleToMember(member, discordServices.roleIDs.attendeeRole)
-                    discordServices.sendEmbedToMember(user, {
-                        title: 'Attend Success!',
-                        description: 'You have been marked as attending! Happy hacking!!!'
-                    });
+            if (!discordServices.checkForRole(member, discordServices.roleIDs.attendeeRole)) {
+                   Verification.attend(member);
             } else {
                 discordServices.sendEmbedToMember(member, {
                     title: 'Attend Error',

--- a/commands/verification/verify.js
+++ b/commands/verification/verify.js
@@ -1,11 +1,11 @@
 // Discord.js commando requirements
 const PermissionCommand = require('../../classes/permission-command');
-const firebaseServices = require('../../firebase-services/firebase-services');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
+const Verification = require('../../classes/verification');
 
 // Command export
-module.exports = class Verification extends PermissionCommand {
+module.exports = class Verify extends PermissionCommand {
     constructor(client) {
         super(client, {
             name: 'verify',
@@ -19,7 +19,11 @@ module.exports = class Verification extends PermissionCommand {
                     type: 'string',
                     default: '',
                 },
-                
+                {
+                    key: 'guildId',
+                    prompt: 'Please provide the server ID, ask admins for it!',
+                    type: 'number',
+                },
             ],
         },
         {
@@ -32,7 +36,7 @@ module.exports = class Verification extends PermissionCommand {
      * @param {Discord.Message} message 
      * @param {String} email 
      */
-    async runCommand(message, { email }) {
+    async runCommand(message, { email, guildId }) {
         // make email lowercase
         email = email.toLowerCase();
 
@@ -45,7 +49,7 @@ module.exports = class Verification extends PermissionCommand {
             return;
         }
 
-        let guild = message.channel.client.guilds.cache.first();
+        let guild = this.client.guilds.cache.get(guildId);
         let member = guild.member(message.author.id);
 
         // check if the user needs to verify, else warn and return
@@ -57,59 +61,9 @@ module.exports = class Verification extends PermissionCommand {
             return;
         }
 
-        // Call the verify function to get status
-        var status = await firebaseServices.verify(email, message.author.id);
+        // Call the verify function
+        Verification.verify(member, email, guild);
 
-        // embed to send
-        const embed = new Discord.MessageEmbed()
-            .setTitle('Verification Process')
-            .setColor(discordServices.colors.specialDMEmbedColor);
-    
-        switch(status) {
-            case firebaseServices.status.HACKER_SUCCESS:
-                embed.addField('You Have Been Verified!', 'Thank you for verifying your status with us, you now have access to most of the server.')
-                    .addField('Don\'t Forget!', 'Remember you need to !attend <your email> in the attend channel that will open a few hours before the hackathon begins.');
-                discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.hackerRole);
-                discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
-                if (discordServices.stampRoles.has(0)) discordServices.addRoleToMember(member,discordServices.stampRoles.get(0));
-                discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and they are now a hacker!");
-                break;
-            case firebaseServices.status.SPONSOR_SUCCESS:
-                if (discordServices.roleIDs?.sponsorRole) {
-                    embed.addField('You Have Been Verified!', 'Hi there sponsor, thank you very much for being part of nwhacks 2021 and for joining our discord!');
-                    discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.sponsorRole);
-                    discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
-                    discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and they are now a sponsor!");
-                }
-                break;
-            case firebaseServices.status.MENTOR_SUCCESS:
-                if (discordServices.roleIDs?.mentorRole) {
-                    embed.addField('You Have Been Verified!', 'Hi there mentor, thank you very much for being part of nwhacks 2021 and for joining our discord!');
-                    discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.mentorRole);
-                    discordServices.addRoleToMember(member,discordServices.roleIDs.memberRole);
-                    discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and he is now a mentor!");
-                }
-                break;
-            case firebaseServices.status.STAFF_SUCCESS:
-                embed.addField('Welcome To Your Server!', 'Welcome to your discord server! If you need to know more about what I can do please call !help.');
-                discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.staffRole);
-                discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and he is now a staff!");
-                break;
-            case firebaseServices.status.FAILURE:
-                embed.addField('ERROR 404', 'Hi there, the email you tried to verify yourself with is not' +
-                ' in our system, please make sure your email is well typed. If you think this is an error' +
-                ' please contact us in the welcome-support channel.')
-                    .setColor('#fc1403');
-                discordServices.discordLog(guild, 'VERIFY ERROR : <@' + message.author.id + '> Tried to verify email: ' + email + ' and failed! I couldn\'t find that email!');
-                break;
-            default:
-                embed.addField('ERROR 401', 'Hi there, it seems the email you tried to verify with is already in use or you were not accepted! Please make ' +
-                    'sure that you have the correct email. If you think this is an error please contact us in the welcome-support channel.')
-                    .setColor('#fc1403');
-                    discordServices.discordLog(guild, 'VERIFY WARNING : <@' + message.author.id + '> Tried to verify email: ' + email + ' and failed! He already verified or was not accepted!');
-                break;
-        }
-        discordServices.sendMessageToMember(member, embed);
     }
 
 };

--- a/commands/verification/verify.js
+++ b/commands/verification/verify.js
@@ -22,7 +22,7 @@ module.exports = class Verify extends PermissionCommand {
                 {
                     key: 'guildId',
                     prompt: 'Please provide the server ID, ask admins for it!',
-                    type: 'number',
+                    type: 'integer',
                 },
             ],
         },

--- a/commands/verification/verify.js
+++ b/commands/verification/verify.js
@@ -47,14 +47,8 @@ module.exports = class Verify extends PermissionCommand {
             return;
         }
 
-        // make email lowercase
-        email = email.toLowerCase();
-
-        // regex to validate email
-        const re = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
-
         // let user know he has used the command incorrectly and exit
-        if (email === '' || !re.test(email)) {
+        if (!discordServices.validateEmail(email)) {
             discordServices.sendMessageToMember(message.author, 'You have used the verify command incorrectly! \nPlease write a valid email after the command like this: !verify email@gmail.com');
             return;
         }
@@ -70,7 +64,14 @@ module.exports = class Verify extends PermissionCommand {
         let member = guild.member(message.author.id);
 
         // Call the verify function
-        Verification.verify(member, email, guild);
+        try {
+            Verification.verify(member, email, guild);
+        } catch (error) {
+            discordServices.sendEmbedToMember(member, {
+                title: 'Verification Error',
+                description: 'Email provided is not valid!'
+            }, true);
+        }
 
     }
 

--- a/commands/verification/verify.js
+++ b/commands/verification/verify.js
@@ -37,6 +37,16 @@ module.exports = class Verify extends PermissionCommand {
      * @param {String} email 
      */
     async runCommand(message, { email, guildId }) {
+
+        // check if the user needs to verify, else warn and return
+        if (!discordServices.checkForRole(member, discordServices.roleIDs.guestRole)) {
+            discordServices.sendEmbedToMember(member, {
+                title: 'Verify Error',
+                description: 'You do not need to verify, you are already more than a guest!'
+            }, true);
+            return;
+        }
+
         // make email lowercase
         email = email.toLowerCase();
 
@@ -50,16 +60,14 @@ module.exports = class Verify extends PermissionCommand {
         }
 
         let guild = this.client.guilds.cache.get(guildId);
-        let member = guild.member(message.author.id);
-
-        // check if the user needs to verify, else warn and return
-        if (!discordServices.checkForRole(member, discordServices.roleIDs.guestRole)) {
-            discordServices.sendEmbedToMember(member, {
-                title: 'Verify Error',
-                description: 'You do not need to verify, you are already more than a guest!'
-            }, true);
+        if (!guild) {
+            discordServices.sendEmbedToMember(message.author, {
+                title: 'Verification Failure',
+                description: 'The given server ID is not valid. Please try again!',
+            });
             return;
         }
+        let member = guild.member(message.author.id);
 
         // Call the verify function
         Verification.verify(member, email, guild);

--- a/discord-services.js
+++ b/discord-services.js
@@ -3,6 +3,15 @@ const Discord = require('discord.js');
 // Available Roles
 
 /**
+ * @type {Discord.Collection<String, String>} - <type, roleId>
+ */
+const verificationRoles = new Discord.Collection();
+verificationRoles.set('cmd-f Hacker', '812441340888612924');
+verificationRoles.set('Learn Hacker', '812441385630040086')
+
+ module.exports.verificationRoles = verificationRoles
+
+/**
  * All the available roles from server creation.
  */
 module.exports.roleIDs = {

--- a/discord-services.js
+++ b/discord-services.js
@@ -315,3 +315,24 @@ function randomColor() {
     return Math.floor(Math.random()*16777215).toString(16);
 }
 module.exports.randomColor = randomColor;
+
+/**
+ * Validates an email using a reg exp.
+ * @param {String} email - the email to validate
+ * @returns {Boolean} true if valid email, false otherwise
+ */
+function validateEmail(email) {
+    // make email lowercase
+    email = email.toLowerCase();
+
+    // regex to validate email
+    const re = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+
+    // let user know he has used the command incorrectly and exit
+    if (email === '' || !re.test(email)) {
+        return false;
+    } else {
+        return true;
+    }
+}
+module.exports.validateEmail = validateEmail;

--- a/firebase-services/firebase-services.js
+++ b/firebase-services/firebase-services.js
@@ -167,7 +167,7 @@ function addUserData(email, member, types) {
     var newDocument = db.collection('members').doc();
     /** @type {FirebaseUser} */
     let data = {
-        email: email,
+        email: email.toLowerCase(),
         discordId: member.id,
         types: types.map((type, index, array) => {
             /** @type {UserType} */
@@ -191,7 +191,7 @@ module.exports.addUserData = addUserData;
  * @throws Error if the email provided was not found.
  */
 async function verify(email, id) {
-    var userRef = db.collection('members').where('email', '==', email).limit(1);
+    var userRef = db.collection('members').where('email', '==', email.toLowerCase()).limit(1);
     var user = (await userRef.get()).docs[0];
 
     if (user) {

--- a/firebase-services/firebase-services.js
+++ b/firebase-services/firebase-services.js
@@ -6,37 +6,6 @@ const admin = require('firebase-admin');
 const db = admin.firestore();
 module.exports.db = db;
 
-
-/**
- * @typedef FirebaseStatus
- * @property {String} HACKER_SUCCESS - hacker related job was successful
- * @property {String} HACKER_IN_USE - hacker related job was not successful due to operation already been done
- * @property {String} SPONSOR_SUCCESS - sponsor related job was successful
- * @property {String} SPONSOR_IN_USE - sponsor related job was not successful due to operation already been done
- * @property {String} MENTOR_SUCCESS - mentor related job was successful
- * @property {String} MENTOR_IN_USE - mentor related job was not successful due to operation already been done
- * @property {String} STAFF_SUCCESS - staff related job was successful
- * @property {String} STAFF_IN_USE - staff related job was not successful due to operation already been done
- * @property {String} FAILURE - the job was not successful due to an error or the user not being found
- */
-
-/**
- * Different status used by firebase functions to let the user know what happened.
- * @type {FirebaseStatus}
- */
-const status = {
-    HACKER_SUCCESS: "C1",
-    HACKER_IN_USE: "C2",
-    SPONSOR_SUCCESS: "C3",
-    SPONSOR_IN_USE: "C4",
-    MENTOR_SUCCESS: "C5",
-    MENTOR_IN_USE: "C6",
-    STAFF_SUCCESS: "C7",
-    STAFF_IN_USE: "C8",
-    FAILURE: "C0",
-}
-module.exports.status = status;
-
 /**
  * Retrieves a question from the db that has not already been asked at the Discord Contests, then marks the question as having been 
  * asked in the db.

--- a/firebase-services/firebase-services.js
+++ b/firebase-services/firebase-services.js
@@ -171,11 +171,11 @@ function addUserData(email, member, types) {
         discordId: member.id,
         types: types.map((type, index, array) => {
             /** @type {UserType} */
-            let type = {
+            let userType = {
                 type: type,
                 isVerified: false,
             }
-            return type;
+            return userType;
         }),
     };
 

--- a/firebase-services/firebase-services.js
+++ b/firebase-services/firebase-services.js
@@ -1,3 +1,5 @@
+const { GuildMember, } = require('discord.js');
+
 // Firebase requirements
 const admin = require('firebase-admin');
 
@@ -159,32 +161,25 @@ module.exports.checkName = checkName;
  * Adds new document in Firebase members collection for manually verified member
  * @param {String} email - email of member verified
  * @param {GuildMember} member - member verified
- * @param {String} type - type of participant verified
+ * @param {String[]} types - types this user might verify for
  */
-async function addUserData(email, member, type) {
+function addUserData(email, member, types) {
     var newDocument = db.collection('members').doc();
-    if (type === 'hacker') {
-        var verifyLearn = false;
-        if (new Date() < new Date(2021, 1, 28)) {
-            verifyLearn = true;
-        }
-        newDocument.set({
-            'email': email,
-            'type': 'hacker',
-            'discord-id': member.id,
-            'canVerifyLearn': true,
-            'canVerifycmdf': true,
-            'verifiedLearn': verifyLearn,
-            'verifiedcmdf': !verifyLearn,
-        });
-    } else {
-        newDocument.set({
-            'email': email,
-            'type': type,
-            'discord-id': member.id,
-            'verified': true,
-        });
-    }
+    /** @type {FirebaseUser} */
+    let data = {
+        email: email,
+        discordId: member.id,
+        types: types.map((type, index, array) => {
+            /** @type {UserType} */
+            let type = {
+                type: type,
+                isVerified: false,
+            }
+            return type;
+        }),
+    };
+
+    newDocument.set(data);
 }
 module.exports.addUserData = addUserData;
 /**

--- a/firebase-services/firebase-services.js
+++ b/firebase-services/firebase-services.js
@@ -92,7 +92,7 @@ async function verify(email, id) {
         data.types.forEach((value, index, array) => {
             if (!value.isVerified) {
                 value.isVerified = true;
-                value.timestamp = admin.firestore.Timestamp.now();
+                value.VerifiedTimestamp = admin.firestore.Timestamp.now();
                 returnTypes.push(value.type);
             }
         });
@@ -107,3 +107,32 @@ async function verify(email, id) {
     }
 }
 module.exports.verify = verify;
+
+/**
+ * Attends the user via their discord id
+ * @param {String} id - the user's discord snowflake
+ * @returns {Promise<String[]>} - the types this user is verified
+ * @async
+ * @throws Error if the email provided was not found.
+ */
+async function attend(id) {
+    var userRef = db.collection('members').where('discordId', '==', id).limit(1);
+    var user = (await userRef.get()).docs[0];
+
+    if (user) {
+        /** @type {FirebaseUser} */
+        var data = user.data();
+
+        data.types.forEach((value, index, array) => {
+            if (value.isVerified) {
+                value.isAttending = true;
+                value.AttendingTimestamp = admin.firestore.Timestamp.now();
+            }
+        });
+
+        user.ref.update(data);
+    } else {
+        throw new Error('The email provided was not found!');
+    }
+}
+module.exports.attend = attend;

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ bot.once('ready', async () => {
     bot.user.setActivity('Ready to hack!');
 });
 
-bot.on('guildCreate', /** @param {Commando.CommandoGuild} guild */ (guild) => {
+bot.on('guildCreate', /** @param {Commando.CommandoGuild} guild */(guild) => {
     bot.registry.groups.forEach((group, key, map) => {
         if (!group.guarded) guild.setGroupEnabled(group, false);
     });
@@ -82,17 +82,17 @@ bot.on('guildCreate', /** @param {Commando.CommandoGuild} guild */ (guild) => {
 // Listeners for the bot
 
 // error event
-bot.on('error', (error) => {
-    console.log(error)
-    discordServices.discordLog(bot.guilds.cache.first(), )
-});
+// bot.on('error', (error) => {
+//     console.log(error)
+//     discordServices.discordLog(bot.guilds.cache.first(), )
+// });
 
 bot.on('commandError', (command, error) => {
     console.log(
-        'Error on command: ' + command.name + 
-        'Uncaught Rejection, reason: ' + error.name + 
+        'Error on command: ' + command.name +
+        'Uncaught Rejection, reason: ' + error.name +
         '\nmessage: ' + error.message +
-        '\nfile: ' + error.fileName + 
+        '\nfile: ' + error.fileName +
         '\nline number: ' + error.lineNumber +
         '\nstack: ' + error.stack
     );
@@ -100,61 +100,61 @@ bot.on('commandError', (command, error) => {
     discordServices.discordLog(bot.guilds.cache.first(),
         new Discord.MessageEmbed().setColor('#ed3434')
             .setTitle('Command Error')
-            .setDescription('Error on command: ' + command.name +  
-            'Uncaught Rejection, reason: ' + error.name + 
-            '\nmessage: ' + error.message +
-            '\nfile: ' + error.fileName + 
-            '\nline number: ' + error.lineNumber +
-            '\nstack: ' + error.stack)
+            .setDescription('Error on command: ' + command.name +
+                'Uncaught Rejection, reason: ' + error.name +
+                '\nmessage: ' + error.message +
+                '\nfile: ' + error.fileName +
+                '\nline number: ' + error.lineNumber +
+                '\nstack: ' + error.stack)
             .setTimestamp()
     );
 });
 
 process.on('uncaughtException', (error, origin) => {
     console.log(
-        'Uncaught Rejection, reason: ' + error.name + 
+        'Uncaught Rejection, reason: ' + error.name +
         '\nmessage: ' + error.message +
-        '\nfile: ' + error.fileName + 
+        '\nfile: ' + error.fileName +
         '\nline number: ' + error.lineNumber +
-        '\nstack: ' + error.stack + 
+        '\nstack: ' + error.stack +
         `Exception origin: ${origin}`
     );
     discordServices.discordLog(bot.guilds.cache.first(),
         new Discord.MessageEmbed().setColor('#ed3434')
             .setTitle('Uncaught Rejection')
-            .setDescription('Uncaught Rejection, reason: ' + error.name + 
-            '\nmessage: ' + error.message +
-            '\nfile: ' + error.fileName + 
-            '\nline number: ' + error.lineNumber +
-            '\nstack: ' + error.stack + 
-            `\nException origin: ${origin}`)
+            .setDescription('Uncaught Rejection, reason: ' + error.name +
+                '\nmessage: ' + error.message +
+                '\nfile: ' + error.fileName +
+                '\nline number: ' + error.lineNumber +
+                '\nstack: ' + error.stack +
+                `\nException origin: ${origin}`)
             .setTimestamp()
     );
 });
 
 process.on('unhandledRejection', (error, promise) => {
-    console.log('Unhandled Rejection at:', promise, 
-        'Unhandled Rejection, reason: ' + error.name + 
+    console.log('Unhandled Rejection at:', promise,
+        'Unhandled Rejection, reason: ' + error.name +
         '\nmessage: ' + error.message +
-        '\nfile: ' + error.fileName + 
+        '\nfile: ' + error.fileName +
         '\nline number: ' + error.lineNumber +
         '\nstack: ' + error.stack
     );
     discordServices.discordLog(bot.guilds.cache.first(),
         new Discord.MessageEmbed().setColor('#ed3434')
             .setTitle('Unhandled Rejection')
-            .setDescription('Unhandled Rejection, reason: ' + error.name + 
-            '\nmessage: ' + error.message +
-            '\nfile: ' + error.fileName + 
-            '\nline number: ' + error.lineNumber)
+            .setDescription('Unhandled Rejection, reason: ' + error.name +
+                '\nmessage: ' + error.message +
+                '\nfile: ' + error.fileName +
+                '\nline number: ' + error.lineNumber)
             .setTimestamp()
     );
 });
 
 process.on('exit', () => {
     console.log('Node is exiting!');
-    discordServices.discordLog(bot.guilds.cache.first(), 
-    new Discord.MessageEmbed().setColor('#ed3434')
+    discordServices.discordLog(bot.guilds.cache.first(),
+        new Discord.MessageEmbed().setColor('#ed3434')
             .setTitle('Unhandled Rejection')
             .setDescription('The program is shutting down!')
             .setTimestamp());
@@ -201,8 +201,9 @@ async function greetNewMember(member) {
         .addField('Want to learn more about what I can do?', 'Use the !help command anywhere and I will send you a message!')
         .setColor(discordServices.colors.embedColor);
 
-    if (discordServices.roleIDs?.guestRole) embed.addField('Gain more access by verifying yourself!', 'React to this message with ' + verifyEmoji + ' and follow my instructions!');
-    
+    if (discordServices.roleIDs?.guestRole) embed
+        .addField('Gain more access by verifying yourself!', 'React to this message with ' + verifyEmoji + ' and follow my instructions!')
+        .addField('** Note that verification for the cmd-f 2021 hackathon opens Feb.28, 2021**');
     let msg = await member.send(embed);
 
     // if verification is on then give guest role and let user verify
@@ -210,29 +211,38 @@ async function greetNewMember(member) {
         discordServices.addRoleToMember(member, discordServices.roleIDs.guestRole);
 
         msg.react(verifyEmoji);
-
+        var verifycmdfDate = new Date(2021, 1, 28); // Feb 28, 2021
         let verifyCollector = msg.createReactionCollector((reaction, user) => !user.bot && reaction.emoji.name === verifyEmoji);
 
         verifyCollector.on('collect', async (reaction, user) => {
+            var today = new Date();
             try {
-                var email = (await Prompt.messagePrompt('What email did you get accepted to this event? Please send it now!', 'string', member.user.dmChannel, member.id, 25)).content;
+                var prompt;
+                if (today < verifycmdfDate) {
+                    prompt = 'cmd-f Learn';
+                } else {
+                    prompt = 'cmd-f 2021';
+                }
+                var email = (await Prompt.messagePrompt('What email did you get accepted to ' + prompt + ' with? Please send it now!', 'string', member.user.dmChannel, member.id, 25)).content;
             } catch (error) {
                 discordServices.sendEmbedToMember(member, {
                     title: 'Verification Error',
                     description: 'Email was not provided, please try again!'
                 }, true);
-                return; 
+                return;
             }
-            reaction.users.remove(user.id);
-
-            let success = await verify(member, email, member.guild);
-
-            if (success) {
+            var cmdfVerified = false;
+            if (today < verifycmdfDate) {
+                await verifyLearn(member, email, member.guild);
+            } else {
+                cmdfVerified = await verify(member, email, member.guild);
+            }
+            if (cmdfVerified || discordServices.checkForRole(member, discordServices.roleIDs.mentorRole) ||
+                discordServices.checkForRole(member, discordServices.roleIDs.sponsorRole)) {
                 verifyCollector.stop();
             }
-
         });
-    } 
+    }
     // if verification is off, then just ive member role
     else {
         discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
@@ -249,12 +259,12 @@ async function fixDMIssue(error, member) {
     if (error.code === 50007) {
         let channelID = discordServices.channelIDs?.welcomeChannel || discordServices.channelIDs.botSupportChannel;
 
-        member.guild.channels.resolve(channelID).send('<@' + member.id + '> I couldn\'t reach you :(.' + 
-            '\n* Please turn on server DMs, explained in this link: https://support.discord.com/hc/en-us/articles/217916488-Blocking-Privacy-Settings-' + 
+        member.guild.channels.resolve(channelID).send('<@' + member.id + '> I couldn\'t reach you :(.' +
+            '\n* Please turn on server DMs, explained in this link: https://support.discord.com/hc/en-us/articles/217916488-Blocking-Privacy-Settings-' +
             '\n* Once this is done, please react to this message with 🤖 to let me know!').then(msg => {
                 msg.react('🤖');
                 const collector = msg.createReactionCollector((reaction, user) => user.id === member.id && reaction.emoji.name === '🤖');
-                
+
                 collector.on('collect', (reaction, user) => {
                     reaction.users.remove(user.id);
                     try {
@@ -262,7 +272,7 @@ async function fixDMIssue(error, member) {
                         collector.stop();
                         msg.delete();
                     } catch (error) {
-                        member.guild.channels.resolve(channelID).send('<@' + member.id + '> Are you sure you made the changes? I couldn\'t reach you again 😕').then(msg => msg.delete({timeout: 8000}));
+                        member.guild.channels.resolve(channelID).send('<@' + member.id + '> Are you sure you made the changes? I couldn\'t reach you again 😕').then(msg => msg.delete({ timeout: 8000 }));
                     }
                 });
             });
@@ -281,7 +291,7 @@ async function fixDMIssue(error, member) {
  * @private
  * @async
  */
-async function verify(member, email, guild) {
+async function verifyLearn(member, email, guild) {
     // make email lowercase
     email = email.toLowerCase();
 
@@ -295,10 +305,13 @@ async function verify(member, email, guild) {
     }
 
     // check if the user needs to verify, else warn and return
-    if (!discordServices.checkForRole(member, discordServices.roleIDs.guestRole)) {
+    if (discordServices.checkForRole(member, discordServices.roleIDs.sponsorRole) ||
+        discordServices.checkForRole(member, discordServices.roleIDs.mentorRole ||
+            discordServices.checkForRole(member, discordServices.roleIDs.staffRole ||
+                discordServices.checkForRole(member, discordServices.roleIDs.hackerRole)))) {
         discordServices.sendEmbedToMember(member, {
             title: 'Verify Error',
-            description: 'You do not need to verify, you are already more than a guest!'
+            description: 'You have already verified for Learn!'
         }, true);
         return;
     }
@@ -308,21 +321,22 @@ async function verify(member, email, guild) {
 
     // embed to send
     const embed = new Discord.MessageEmbed()
-        .setTitle('Verification Process')
+        .setTitle('cmd-f Learn Verification Process')
         .setColor(discordServices.colors.specialDMEmbedColor);
 
-    switch(status) {
+    var success = true;
+    switch (status) {
         case firebaseServices.status.HACKER_SUCCESS:
             embed.addField('You Have Been Verified!', 'Thank you for verifying your status with us, you now have access to most of the server.')
-                .addField('Don\'t Forget!', 'Remember you need to !attend <your email> in the attend channel that will open a few hours before the hackathon begins.');
+                .addField('Don\'t Forget!', 'Remember if you are attending the cmd-f hackathon, that has a separate verification process before the hackathon begins.');
             discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.hackerRole);
-            if (discordServices.stampRoles.has(0)) discordServices.addRoleToMember(member,discordServices.stampRoles.get(0));
-            discordServices.addRoleToMember(member,discordServices.roleIDs.memberRole);
+            if (discordServices.stampRoles.has(0)) discordServices.addRoleToMember(member, discordServices.stampRoles.get(0));
+            discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
             discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a hacker!");
             break;
         case firebaseServices.status.SPONSOR_SUCCESS:
             if (discordServices.roleIDs?.sponsorRole) {
-                embed.addField('You Have Been Verified!', 'Hi there sponsor, thank you very much for being part of nwhacks 2021 and for joining our discord!');
+                embed.addField('You Have Been Verified!', 'Hi there sponsor, thank you very much for being part of cmd-f 2021 and for joining our discord!');
                 discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.sponsorRole);
                 discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
                 discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and they are now a sponsor!");
@@ -330,31 +344,89 @@ async function verify(member, email, guild) {
             break;
         case firebaseServices.status.MENTOR_SUCCESS:
             if (discordServices.roleIDs?.mentorRole) {
-                embed.addField('You Have Been Verified!', 'Hi there mentor, thank you very much for being part of nwhacks 2021 and for joining our discord!');
+                embed.addField('You Have Been Verified!', 'Hi there mentor, thank you very much for being part of cmd-f 2021 and for joining our discord!');
                 discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.mentorRole);
-                discordServices.addRoleToMember(member,discordServices.roleIDs.memberRole);
-                discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and he is now a mentor!");
+                discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
+                discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a mentor!");
             }
             break;
         case firebaseServices.status.STAFF_SUCCESS:
             embed.addField('Welcome To Your Server!', 'Welcome to your discord server! If you need to know more about what I can do please call !help.');
             discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.staffRole);
-            discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and he is now a staff!");
+            discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a staff!");
             break;
         case firebaseServices.status.FAILURE:
             embed.addField('ERROR 404', 'Hi there, the email you tried to verify yourself with is not' +
-            ' in our system, please make sure your email is well typed. If you think this is an error' +
-            ' please contact us in the welcome-support channel.')
+                ' in our system, please make sure your email is well typed. If you think this is an error' +
+                ' please contact us in the welcome-support channel.')
                 .setColor('#fc1403');
             discordServices.discordLog(guild, 'VERIFY ERROR : <@' + member.id + '> Tried to verify email: ' + email + ' and failed! I couldn\'t find that email!');
+            success = false;
             break;
         default:
             embed.addField('ERROR 401', 'Hi there, it seems the email you tried to verify with is already in use or you were not accepted! Please make ' +
                 'sure that you have the correct email. If you think this is an error please contact us in the welcome-support channel.')
                 .setColor('#fc1403');
-                discordServices.discordLog(guild, 'VERIFY WARNING : <@' + member.id + '> Tried to verify email: ' + email + ' and failed! He already verified or was not accepted!');
+            discordServices.discordLog(guild, 'VERIFY WARNING : <@' + member.id + '> Tried to verify email: ' + email + ' and failed! They already verified or was not accepted!');
+            success = false;
             break;
     }
     discordServices.sendMessageToMember(member, embed);
-    return true;
+    return success;
+}
+
+async function verify(member, email, guild) {
+    email = email.toLowerCase();
+
+    // regex to validate email
+    const re = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+
+    // let user know he has used the command incorrectly and exit
+    if (email === '' || !re.test(email)) {
+        discordServices.sendMessageToMember(member, 'The email you sent me is not valid, please try again!');
+        return;
+    }
+
+    // check if the user needs to verify, else warn and return
+    if (discordServices.checkForRole(member, discordServices.roleIDs.sponsorRole) ||
+        discordServices.checkForRole(member, discordServices.roleIDs.mentorRole ||
+            discordServices.checkForRole(member, discordServices.roleIDs.staffRole ||
+                discordServices.checkForRole(member, discordServices.roleIDs.attendeeRole)))) {
+        discordServices.sendEmbedToMember(member, {
+            title: 'Verify Error',
+            description: 'You already verified for cmd-f 2021!'
+        }, true);
+        return;
+    }
+
+    // call the firebase services attendHacker function
+    var status = await firebaseServices.attendHacker(email);
+
+    // embed to use
+    const embed = new Discord.MessageEmbed()
+        .setColor(discordServices.colors.specialDMEmbedColor)
+        .setTitle('cmd-f Verification Process');
+
+    var success = true;
+    // Check the returned status and act accordingly!
+    switch (status) {
+        case firebaseServices.status.HACKER_SUCCESS:
+            embed.addField('Thank you for attending cmd-f 2021', 'Happy hacking!!!');
+            discordServices.addRoleToMember(member, discordServices.roleIDs.attendeeRole);
+            discordServices.discordLog(guild, "ATTEND SUCCESS : <@" + message.author.id + "> with email: " + email + " is attending cmd-f 2021!");
+            break;
+        case firebaseServices.status.HACKER_IN_USE:
+            embed.addField('Hi there, this email is already marked as verified for cmd-f', 'Have a great day!')
+            break;
+        case firebaseServices.status.FAILURE:
+            embed.addField('ERROR 401', 'Hi there, the email you tried to verify with is not' +
+                ' in our system, please make sure your email is well typed. If you think this is an error' +
+                ' please contact us in the support channel.')
+                .setColor('#fc1403');
+            discordServices.discordLog(guild, "ATTEND ERROR : <@" + message.author.id + "> with email: " + email + " tried to attend but I did not find his email!");
+            success = false;
+            break;
+    }
+    discordServices.sendMessageToMember(member, embed);
+    return success;
 }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ const nwFirebase = firebase.initializeApp(nwFirebaseConfig, 'nwFirebase');
 
 const discordServices = require('./discord-services');
 const Prompt = require('./classes/prompt');
-const firebaseServices = require('./firebase-services/firebase-services');
 const Verification = require('./classes/verification');
 
 
@@ -178,8 +177,6 @@ bot.on('guildMemberAdd', async member => {
 });
 
 bot.login(config.token).catch(console.error);
-
-
 
 
 /**

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ async function greetNewMember(member) {
 
     if (discordServices.roleIDs?.guestRole) embed
         .addField('Gain more access by verifying yourself!', 'React to this message with ' + verifyEmoji + ' and follow my instructions!\n' +
-        '**Note that verification for the cmd-f 2021 hackathon opens Feb.28, 2021**');
+            '**Note that verification for the cmd-f 2021 hackathon opens Feb.28, 2021**');
     let msg = await member.send(embed);
 
     // if verification is on then give guest role and let user verify
@@ -233,7 +233,7 @@ async function greetNewMember(member) {
                 cmdfVerified = await verify(member, email, member.guild);
             }
             if (cmdfVerified || discordServices.checkForRole(member, discordServices.roleIDs.mentorRole) ||
-                discordServices.checkForRole(member, discordServices.roleIDs.sponsorRole)) {
+                discordServices.checkForRole(member, discordServices.roleIDs.sponsorRole) || discordServices.checkForRole(member, discordServices.roleIDs.staffRole)) {
                 verifyCollector.stop();
             }
         });
@@ -282,7 +282,6 @@ async function fixDMIssue(error, member) {
  * @param {Discord.GuildMember} member - member to verify
  * @param {String} email - email to verify with
  * @param {Discord.Guild} guild - guild to verify member in
- * @returns {Promise<Boolean>} - true if successful
  * @private
  * @async
  */
@@ -319,13 +318,12 @@ async function verifyLearn(member, email, guild) {
         .setTitle('cmd-f Learn Verification Process')
         .setColor(discordServices.colors.specialDMEmbedColor);
 
-    var success = true;
     switch (status) {
         case firebaseServices.status.HACKER_SUCCESS:
             embed.addField('You Have Been Verified!', 'Thank you for verifying your status with us, you now have access to most of the server.')
                 .addField('Don\'t Forget!', 'Remember if you are attending the cmd-f hackathon, that has a separate verification process before the hackathon begins.');
             discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.memberRole);
-            if (discordServices.stampRoles.has(0)) discordServices.addRoleToMember(member, discordServices.stampRoles.get(0));
+            if (discordServices.stampRoles.size > 0) discordServices.addRoleToMember(member, discordServices.stampRoles.get(0));
             discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a hacker!");
             break;
         case firebaseServices.status.SPONSOR_SUCCESS:
@@ -349,24 +347,27 @@ async function verifyLearn(member, email, guild) {
             discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.staffRole);
             discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a staff!");
             break;
+        case firebaseServices.status.HACKER_IN_USE:
+        case firebaseServices.status.MENTOR_IN_USE:
+        case firebaseServices.status.SPONSOR_IN_USE:
+            embed.addField('Hi there, this email is already marked as verified for cmd-f Learn',
+                'If you did not already verify, please contact us in the welcome-support channel');
+            break;
         case firebaseServices.status.FAILURE:
             embed.addField('ERROR 404', 'Hi there, the email you tried to verify yourself with is not' +
                 ' in our system, please make sure your email is well typed. If you think this is an error' +
                 ' please contact us in the welcome-support channel.')
                 .setColor('#fc1403');
             discordServices.discordLog(guild, 'VERIFY ERROR : <@' + member.id + '> Tried to verify email: ' + email + ' and failed! I couldn\'t find that email!');
-            success = false;
             break;
         default:
             embed.addField('ERROR 401', 'Hi there, it seems that you have already verified for cmd-f Learn or you were not accepted! Please make ' +
                 'sure that you have the correct email. If you think this is an error please contact us in the welcome-support channel.')
                 .setColor('#fc1403');
             discordServices.discordLog(guild, 'VERIFY WARNING : <@' + member.id + '> Tried to verify email: ' + email + ' and failed! They already verified or was not accepted!');
-            success = false;
             break;
     }
     discordServices.sendMessageToMember(member, embed);
-    return success;
 }
 
 async function verify(member, email, guild) {
@@ -394,7 +395,7 @@ async function verify(member, email, guild) {
     }
 
     // call the firebase services attendHacker function
-    var status = await firebaseServices.attendUser(email);
+    var status = await firebaseServices.attendUser(email, member.id);
 
     // embed to use
     const embed = new Discord.MessageEmbed()
@@ -408,19 +409,43 @@ async function verify(member, email, guild) {
             embed.addField('Thank you for attending cmd-f 2021', 'Happy hacking!!!');
             if (discordServices.checkForRole(member, discordServices.roleIDs.guestRole)) {
                 discordServices.removeRolToMember(member, discordServices.roleIDs.guestRole);
+                if (discordServices.stampRoles.size > 0) discordServices.addRoleToMember(member, discordServices.stampRoles.get(0));
             }
             discordServices.addRoleToMember(member, discordServices.roleIDs.attendeeRole);
-            discordServices.discordLog(guild, "ATTEND SUCCESS : <@" + member.id + "> with email: " + email + " is attending cmd-f 2021!");
+            discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> with email: " + email + " is attending cmd-f 2021!");
             break;
         case firebaseServices.status.HACKER_IN_USE:
-            embed.addField('Hi there, this email is already marked as verified for cmd-f 2021', 'Have a great day!')
+        case firebaseServices.status.MENTOR_IN_USE:
+        case firebaseServices.status.SPONSOR_IN_USE:
+            embed.addField('Hi there, this email is already marked as verified for cmd-f 2021',
+                'If you did not already verify, please contact us in the welcome-support channel');
+            success = false;
+            break;
+        case firebaseServices.status.MENTOR_SUCCESS:
+            if (discordServices.roleIDs?.mentorRole) {
+                embed.addField('You Have Been Verified!', 'Hi there mentor, thank you very much for being part of cmd-f 2021 and for joining our discord!');
+                discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.mentorRole);
+                discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a mentor!");
+            }
+            break;
+        case firebaseServices.status.SPONSOR_SUCCESS:
+            if (discordServices.roleIDs?.sponsorRole) {
+                embed.addField('You Have Been Verified!', 'Hi there sponsor, thank you very much for being part of cmd-f 2021 and for joining our discord!');
+                discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.sponsorRole);
+                discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and they are now a sponsor!");
+            }
+            break;
+        case firebaseServices.status.STAFF_SUCCESS:
+            embed.addField('Welcome To Your Server!', 'Welcome to your discord server! If you need to know more about what I can do please call !help.');
+            discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.staffRole);
+            discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a staff!");
             break;
         case firebaseServices.status.FAILURE:
             embed.addField('ERROR 401', 'Hi there, the email you tried to verify with is not' +
                 ' in our system, please make sure your email is well typed. If you think this is an error' +
                 ' please contact us in the support channel.')
                 .setColor('#fc1403');
-            discordServices.discordLog(guild, "ATTEND ERROR : <@" + member.id + "> with email: " + email + " tried to attend but I did not find his email!");
+            discordServices.discordLog(guild, "VERIFY ERROR : <@" + member.id + "> with email: " + email + " tried to attend but I did not find their email!");
             success = false;
             break;
     }

--- a/index.js
+++ b/index.js
@@ -216,7 +216,14 @@ async function greetNewMember(member) {
                 return;
             }
 
-            Verification.verify(member, email, member.guild);
+            try {
+                Verification.verify(member, email, member.guild);
+            } catch (error) {
+                discordServices.sendEmbedToMember(member, {
+                    title: 'Verification Error',
+                    description: 'Email provided is not valid! Please try again.'
+                }, true);
+            }
         });
     }
     // if verification is off, then just ive member role

--- a/index.js
+++ b/index.js
@@ -212,13 +212,13 @@ async function greetNewMember(member) {
         verifyCollector.on('collect', async (reaction, user) => {
             var today = new Date();
             try {
-                var prompt;
+                var event;
                 if (today < verifycmdfDate) {
-                    prompt = 'cmd-f Learn';
+                    event = 'cmd-f Learn';
                 } else {
-                    prompt = 'cmd-f 2021';
+                    event = 'cmd-f 2021';
                 }
-                var email = (await Prompt.messagePrompt('What email did you get accepted to ' + prompt + ' with? Please send it now!', 'string', member.user.dmChannel, member.id, 25)).content;
+                var email = (await Prompt.messagePrompt({prompt: 'What email did you get accepted to ' + event + ' with? Please send it now!', channel: member.user.dmChannel, userId: member.id}, 'string', 25)).content;
             } catch (error) {
                 discordServices.sendEmbedToMember(member, {
                     title: 'Verification Error',
@@ -330,7 +330,7 @@ async function verifyLearn(member, email, guild) {
             if (discordServices.roleIDs?.sponsorRole) {
                 embed.addField('You Have Been Verified!', 'Hi there sponsor, thank you very much for being part of cmd-f 2021 and for joining our discord!');
                 discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.sponsorRole);
-                //discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
+                discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
                 discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and they are now a sponsor!");
             }
             break;
@@ -338,7 +338,7 @@ async function verifyLearn(member, email, guild) {
             if (discordServices.roleIDs?.mentorRole) {
                 embed.addField('You Have Been Verified!', 'Hi there mentor, thank you very much for being part of cmd-f 2021 and for joining our discord!');
                 discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.mentorRole);
-                //discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
+                discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
                 discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a mentor!");
             }
             break;
@@ -408,7 +408,7 @@ async function verify(member, email, guild) {
         case firebaseServices.status.HACKER_SUCCESS:
             embed.addField('Thank you for attending cmd-f 2021', 'Happy hacking!!!');
             if (discordServices.checkForRole(member, discordServices.roleIDs.guestRole)) {
-                discordServices.removeRolToMember(member, discordServices.roleIDs.guestRole);
+                discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.memberRole);
                 if (discordServices.stampRoles.size > 0) discordServices.addRoleToMember(member, discordServices.stampRoles.get(0));
             }
             discordServices.addRoleToMember(member, discordServices.roleIDs.attendeeRole);
@@ -425,6 +425,7 @@ async function verify(member, email, guild) {
             if (discordServices.roleIDs?.mentorRole) {
                 embed.addField('You Have Been Verified!', 'Hi there mentor, thank you very much for being part of cmd-f 2021 and for joining our discord!');
                 discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.mentorRole);
+                discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
                 discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a mentor!");
             }
             break;
@@ -432,6 +433,7 @@ async function verify(member, email, guild) {
             if (discordServices.roleIDs?.sponsorRole) {
                 embed.addField('You Have Been Verified!', 'Hi there sponsor, thank you very much for being part of cmd-f 2021 and for joining our discord!');
                 discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.sponsorRole);
+                discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
                 discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and they are now a sponsor!");
             }
             break;

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ const nwFirebase = firebase.initializeApp(nwFirebaseConfig, 'nwFirebase');
 const discordServices = require('./discord-services');
 const Prompt = require('./classes/prompt');
 const firebaseServices = require('./firebase-services/firebase-services');
+const Verification = require('./classes/verification');
 
 
 const config = {
@@ -218,7 +219,7 @@ async function greetNewMember(member) {
                 return;
             }
 
-            verifyNew(member, email, member.guild);
+            Verification.verify(member, email, member.guild);
         });
     }
     // if verification is off, then just ive member role
@@ -258,79 +259,3 @@ async function fixDMIssue(error, member) {
         throw error;
     }
 }
-
-/**
- * Verifies a guild member into a guild.
- * @param {Discord.GuildMember} member - member to verify
- * @param {String} email - email to verify with
- * @param {Discord.Guild} guild
- * @private
- * @async
- */
-async function verifyNew(member, email, guild) {
-    // make email lowercase
-    email = email.toLowerCase();
-
-    // regex to validate email
-    const re = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
-
-    // let user know he has used the command incorrectly and exit
-    if (email === '' || !re.test(email)) {
-        discordServices.sendMessageToMember(member, 'The email you sent me is not valid, please try again!', true);
-        return;
-    }
-
-    // try to get member types, error will mean no email was found
-    try {
-        var types = await firebaseServices.verify(email, member.id);
-    } catch (error) {
-        discordServices.sendEmbedToMember(member, {
-            title: 'Verification Failure',
-            description: 'The email provided was not found! If you need assistance ask an admin for help!',
-        });
-        discordServices.discordLog(guild, `VERIFY FAILURE : <@${member.id}> Verified email: ${email} but was a failure, I could not find that email!`);
-        return;
-    }
-
-    // check for types, if no types it means they are already verified with those types
-    if (types.length === 0) {
-        discordServices.sendEmbedToMember(member, {
-            title: 'Verification Warning',
-            description: 'We found your email, but you are already verified! If this is not the case let an admin know!',
-            color: '#fc1403',
-        });
-        discordServices.discordLog(guild, `VERIFY WARNING : <@${member.id}> Verified email: ${email} but he was already verified for all types!`);
-        return;
-    }
-
-    let correctTypes = [];
-    
-    // check for correct types with botGuild verification info and give the roles
-    types.forEach((type, index, array) => {
-        if (discordServices.verificationRoles.has(type)) {
-            discordServices.addRoleToMember(member, discordServices.verificationRoles.get(type));
-            correctTypes.push(type);
-        }
-    });
-
-    // extra check to see if types were found, give stamp role if available and let user know of success
-    if (correctTypes.length > 0) {
-        discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.memberRole);
-        if (discordServices.stampRoles.has(0)) discordServices.addRoleToMember(member, discordServices.stampRoles.get(0));
-        discordServices.sendEmbedToMember(member, {
-            title: 'cmd-f 2021 Verification Success',
-            description: `You have been verified as a ${correctTypes.join()}, good luck and have fun!`,
-            color: discordServices.colors.specialDMEmbedColor,
-        });
-        discordServices.discordLog(guild, `VERIFY SUCCESS : <@${member.id}> Verified email: ${email} successfully as ${correctTypes.join()}`);
-    } else {
-        discordServices.sendEmbedToMember(member, {
-            title: 'Verification Error',
-            description: 'There has been an error, contact an admin ASAP!',
-            color: '#fc1403',
-        });
-        discordServices.discordLog(guild, `VERIFY ERROR : <@${member.id}> Verified email: ${email} had types available, but I could not find them on the botGuild!`);
-    }
-
-
-}   

--- a/index.js
+++ b/index.js
@@ -197,8 +197,8 @@ async function greetNewMember(member) {
         .setColor(discordServices.colors.embedColor);
 
     if (discordServices.roleIDs?.guestRole) embed
-        .addField('Gain more access by verifying yourself!', 'React to this message with ' + verifyEmoji + ' and follow my instructions!')
-        .addField('** Note that verification for the cmd-f 2021 hackathon opens Feb.28, 2021**');
+        .addField('Gain more access by verifying yourself!', 'React to this message with ' + verifyEmoji + ' and follow my instructions!\n' +
+        '**Note that verification for the cmd-f 2021 hackathon opens Feb.28, 2021**');
     let msg = await member.send(embed);
 
     // if verification is on then give guest role and let user verify

--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ async function verifyLearn(member, email, guild) {
     if (discordServices.checkForRole(member, discordServices.roleIDs.sponsorRole) ||
         discordServices.checkForRole(member, discordServices.roleIDs.mentorRole ||
             discordServices.checkForRole(member, discordServices.roleIDs.staffRole ||
-                discordServices.checkForRole(member, discordServices.roleIDs.hackerRole)))) {
+                discordServices.checkForRole(member, discordServices.roleIDs.memberRole)))) {
         discordServices.sendEmbedToMember(member, {
             title: 'Verify Error',
             description: 'You have already verified for Learn!'
@@ -324,16 +324,15 @@ async function verifyLearn(member, email, guild) {
         case firebaseServices.status.HACKER_SUCCESS:
             embed.addField('You Have Been Verified!', 'Thank you for verifying your status with us, you now have access to most of the server.')
                 .addField('Don\'t Forget!', 'Remember if you are attending the cmd-f hackathon, that has a separate verification process before the hackathon begins.');
-            discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.hackerRole);
+            discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.memberRole);
             if (discordServices.stampRoles.has(0)) discordServices.addRoleToMember(member, discordServices.stampRoles.get(0));
-            discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
             discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a hacker!");
             break;
         case firebaseServices.status.SPONSOR_SUCCESS:
             if (discordServices.roleIDs?.sponsorRole) {
                 embed.addField('You Have Been Verified!', 'Hi there sponsor, thank you very much for being part of cmd-f 2021 and for joining our discord!');
                 discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.sponsorRole);
-                discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
+                //discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
                 discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + message.author.id + "> Verified email: " + email + " successfully and they are now a sponsor!");
             }
             break;
@@ -341,7 +340,7 @@ async function verifyLearn(member, email, guild) {
             if (discordServices.roleIDs?.mentorRole) {
                 embed.addField('You Have Been Verified!', 'Hi there mentor, thank you very much for being part of cmd-f 2021 and for joining our discord!');
                 discordServices.replaceRoleToMember(member, discordServices.roleIDs.guestRole, discordServices.roleIDs.mentorRole);
-                discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
+                //discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
                 discordServices.discordLog(guild, "VERIFY SUCCESS : <@" + member.id + "> Verified email: " + email + " successfully and they are now a mentor!");
             }
             break;
@@ -359,7 +358,7 @@ async function verifyLearn(member, email, guild) {
             success = false;
             break;
         default:
-            embed.addField('ERROR 401', 'Hi there, it seems the email you tried to verify with is already in use or you were not accepted! Please make ' +
+            embed.addField('ERROR 401', 'Hi there, it seems that you have already verified for cmd-f Learn or you were not accepted! Please make ' +
                 'sure that you have the correct email. If you think this is an error please contact us in the welcome-support channel.')
                 .setColor('#fc1403');
             discordServices.discordLog(guild, 'VERIFY WARNING : <@' + member.id + '> Tried to verify email: ' + email + ' and failed! They already verified or was not accepted!');
@@ -395,30 +394,33 @@ async function verify(member, email, guild) {
     }
 
     // call the firebase services attendHacker function
-    var status = await firebaseServices.attendHacker(email);
+    var status = await firebaseServices.attendUser(email);
 
     // embed to use
     const embed = new Discord.MessageEmbed()
         .setColor(discordServices.colors.specialDMEmbedColor)
-        .setTitle('cmd-f Verification Process');
+        .setTitle('cmd-f 2021 Verification Process');
 
     var success = true;
     // Check the returned status and act accordingly!
     switch (status) {
         case firebaseServices.status.HACKER_SUCCESS:
             embed.addField('Thank you for attending cmd-f 2021', 'Happy hacking!!!');
+            if (discordServices.checkForRole(member, discordServices.roleIDs.guestRole)) {
+                discordServices.removeRolToMember(member, discordServices.roleIDs.guestRole);
+            }
             discordServices.addRoleToMember(member, discordServices.roleIDs.attendeeRole);
-            discordServices.discordLog(guild, "ATTEND SUCCESS : <@" + message.author.id + "> with email: " + email + " is attending cmd-f 2021!");
+            discordServices.discordLog(guild, "ATTEND SUCCESS : <@" + member.id + "> with email: " + email + " is attending cmd-f 2021!");
             break;
         case firebaseServices.status.HACKER_IN_USE:
-            embed.addField('Hi there, this email is already marked as verified for cmd-f', 'Have a great day!')
+            embed.addField('Hi there, this email is already marked as verified for cmd-f 2021', 'Have a great day!')
             break;
         case firebaseServices.status.FAILURE:
             embed.addField('ERROR 401', 'Hi there, the email you tried to verify with is not' +
                 ' in our system, please make sure your email is well typed. If you think this is an error' +
                 ' please contact us in the support channel.')
                 .setColor('#fc1403');
-            discordServices.discordLog(guild, "ATTEND ERROR : <@" + message.author.id + "> with email: " + email + " tried to attend but I did not find his email!");
+            discordServices.discordLog(guild, "ATTEND ERROR : <@" + member.id + "> with email: " + email + " tried to attend but I did not find his email!");
             success = false;
             break;
     }


### PR DESCRIPTION
1. Instead of one verification step by pressing the emoji on the bot DM, there are now 2, one for Learn and one for cmd-f. Learn verification is active until Feb.28, 2021 and then it will be deactivated and cmd-f verification will be active. 
2. Bot checks for whether the email has been used to sign up for the specific event and automatically rejects if it has not.
3. Updated permissions for activity channels to be visible to members (i.e. Learn participants) instead of attendees (i.e. cmd-f participants).
4. Sponsors, mentors, and staff can verify anytime, doesn't matter if it's during Learn verification or cmd-f verification phase.

Bug fixes:

- fixed a bug where Discord contests still accepted non-exact answers for numbers
- replaced hackerRole instances with memberRole