### PR TITLE
Botguild class creation

### DIFF
--- a/classes/activity-command.js
+++ b/classes/activity-command.js
@@ -2,6 +2,8 @@ const PermissionCommand = require('./permission-command');
 const discordServices = require('../discord-services');
 const Activity = require('./activity');
 const { Message } = require('discord.js');
+const { Document } = require('mongoose');
+const BotGuild = require('../db/botGuildDBObject');
 
 /**
  * The ActivityCommand class is a special class used for activity commands. It extends
@@ -31,9 +33,9 @@ class ActivityCommand extends PermissionCommand {
     /**
      * Asked by our parent PermissionCommand, will contain the code specific to activity commands.
      */
-    runCommand(message, args, fromPattern, result) {
+    runCommand(botGuild, message, args, fromPattern, result) {
         // we don't want this command to be available outside the activity console
-        this.runActivityCommand(message, null, args);
+        this.runActivityCommand(botGuild, message, null, args);
     }
 
 
@@ -41,21 +43,26 @@ class ActivityCommand extends PermissionCommand {
      * The public method to be used to call the command, it will check that an activity is passed!
      * @param {Message} message - the message that has the command
      * @param {Activity} activity - the activity for this command
+     * @async
      */
-    runActivityCommand(message, activity, args) {
+    async runActivityCommand(message, activity, args) {
         if (activity === null) discordServices.replyAndDelete(message, 'This command cannot be called outside an activity console!');
-        else this.activityCommand(message, activity, args);
+        else {
+            let botGuild = await BotGuild.findById(message.guild.id);
+            this.activityCommand(botGuild, message, activity, args);
+        }
     }
 
 
     /**
      * Required class by children, should contain the command code.
+     * @param {Document} botGuild
      * @param {Message} message - the message that has the command
      * @param {Activity} activity - the activity for this activity command
      * @abstract
      * @async
      */
-    async activityCommand(message, activity, args, fromPattern, result) {
+    async activityCommand(botGuild, message, activity, args, fromPattern, result) {
         throw new Error('You need to implement the activityCommand method!');
     }
 }

--- a/classes/activity-manager.js
+++ b/classes/activity-manager.js
@@ -99,16 +99,16 @@ class ActivityManager {
     /**
      * Will let hackers get a stamp for attending an activity.
      * @param {Activity} activity - activity to use
-     * @param {Number} time - time to wait till collector closes, in seconds
+     * @param {Number} [time] - time to wait till collector closes, in seconds
      * @async
      */
-    static async distributeStamp(activity, time = discordServices.stampCollectTime) {
+    static async distributeStamp(activity, time = 60) {
         
         // The users already seen by this stamp distribution.
         let seenUsers = new Discord.Collection();
 
         const promptEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor((await (BotGuild.findById(activity.guild.id))).colors.embedColor)
             .setTitle('React within ' + time + ' seconds of the posting of this message to get a stamp for ' + activity.name + '!');
         
         let promptMsg = await activity.generalText.send(promptEmbed);
@@ -150,7 +150,7 @@ class ActivityManager {
      */
     static parseRole(member, role, activityName) {
         let stampNumber = parseInt(role.name.substring(role.name.length - 2));
-        let newRoleID = discordServices.stampRoles.get(stampNumber + 1);
+        let newRoleID = (await (BotGuild.findById(member.guild.id))).stampRoles.get(stampNumber + 1);
 
         if (newRoleID != undefined) {
             discordServices.replaceRoleToMember(member, role.id, newRoleID);
@@ -174,7 +174,7 @@ class ActivityManager {
         }
 
         let qEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor((await (BotGuild.findById(activity.guild.id))).colors.embedColor)
             .setTitle(title)
             .setDescription(description);
 

--- a/classes/activity-manager.js
+++ b/classes/activity-manager.js
@@ -3,6 +3,7 @@ const firebaseCoffeeChats = require('../firebase-services/firebase-services-coff
 const discordServices = require('../discord-services');
 const Activity = require('./activity');
 const Discord = require('discord.js');
+const BotGuild = require('../db/botGuildDBObject');
 
 
 /**
@@ -45,9 +46,11 @@ class ActivityManager {
      * @param {Activity} activity - the activity to use
      */
     static async mentorShuffle(activity) {
-        if (!discordServices.roleIDs?.memberRole) return;
+        let botGuild = await BotGuild.findById(activity.guild.id);
 
-        let mentors = activity.generalVoice.members.filter(member => discordServices.checkForRole(member, discordServices.roleIDs.mentorRole));
+        if (!botGuild.roleIDs?.mentorRole) return;
+
+        let mentors = activity.generalVoice.members.filter(member => discordServices.checkForRole(member, botGuild.roleIDs.mentorRole));
 
         let channels = activity.category.children.filter(channel => channel.type === 'voice' && channel.id != activity.generalVoice.id);
 

--- a/classes/activity-manager.js
+++ b/classes/activity-manager.js
@@ -100,15 +100,16 @@ class ActivityManager {
      * Will let hackers get a stamp for attending an activity.
      * @param {Activity} activity - activity to use
      * @param {Number} [time] - time to wait till collector closes, in seconds
+     * @param {Document} botGuild
      * @async
      */
-    static async distributeStamp(activity, time = 60) {
+    static async distributeStamp(activity, botGuild, time = 60) {
         
         // The users already seen by this stamp distribution.
         let seenUsers = new Discord.Collection();
 
         const promptEmbed = new Discord.MessageEmbed()
-            .setColor((await (BotGuild.findById(activity.guild.id))).colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('React within ' + time + ' seconds of the posting of this message to get a stamp for ' + activity.name + '!');
         
         let promptMsg = await activity.generalText.send(promptEmbed);
@@ -126,7 +127,7 @@ class ActivityManager {
 
                 let role = member.roles.cache.find(role => regex.test(role.name));
 
-                if (role != undefined) this.parseRole(member, role, activity.name);
+                if (role != undefined) this.parseRole(member, role, activity.name, botGuild);
 
                 seenUsers.set(user.id, user.username);
             }
@@ -146,11 +147,12 @@ class ActivityManager {
      * @param {Discord.GuildMember} member - the member to add the new role to
      * @param {Discord.Role} role - the current role
      * @param {String} activityName - the name of the activity
+     * @param {Document} botGuild
      * @private
      */
-    static parseRole(member, role, activityName) {
+    static parseRole(member, role, activityName, botGuild) {
         let stampNumber = parseInt(role.name.substring(role.name.length - 2));
-        let newRoleID = (await (BotGuild.findById(member.guild.id))).stampRoles.get(stampNumber + 1);
+        let newRoleID = botGuild.stampRoles.get(stampNumber + 1);
 
         if (newRoleID != undefined) {
             discordServices.replaceRoleToMember(member, role.id, newRoleID);
@@ -165,8 +167,9 @@ class ActivityManager {
      * @param {String} title - the title of the poll
      * @param {String} question - the question to poll for
      * @param {Discord.Collection<String, String>} response - <Emoji, Response> A collection, in order of emojis with its response
+     * @param {Document} botGuild
      */
-    static sendPoll(activity, title, question, response){
+    static sendPoll(activity, title, question, response, botGuild){
         // create poll
         let description = question + '\n\n';
         for (const key of response.keys()) {
@@ -174,7 +177,7 @@ class ActivityManager {
         }
 
         let qEmbed = new Discord.MessageEmbed()
-            .setColor((await (BotGuild.findById(activity.guild.id))).colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle(title)
             .setDescription(description);
 

--- a/classes/activity.js
+++ b/classes/activity.js
@@ -157,7 +157,7 @@ class Activity {
         return this.guild.channels.create(this.name, {
             type: 'category',
             position: position >= 0 ? position : 0,
-            permissionOverwrites: this.botGuild.attendance?.attendeeRoleID ? [ // only lock the activity if the attendance role is in use
+            permissionOverwrites: this.botGuild.attendance.isEnabled ? [ // only lock the activity if the attendance role is in use
                 {
                     id: this.botGuild.roleIDs.everyoneRole,
                     deny: ['VIEW_CHANNEL']
@@ -372,6 +372,7 @@ class Activity {
             await discordServices.deleteChannel(channels[i]);
         }
 
+        this.botGuild.save();
         await discordServices.deleteChannel(this.category);
 
         firebaseActivity.remove(this.name);

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -1,5 +1,6 @@
 const { Collection, Snowflake, Guild, TextChannel, Role, GuildAuditLogs } = require('discord.js');
 const { CommandoClient, CommandoGuild } = require('discord.js-commando');
+const discordServices = require('../discord-services');
 
 module.exports = class BotGuild {
 
@@ -423,6 +424,31 @@ module.exports = class BotGuild {
         // });
     }
 
-    
+    /**
+     * Creates the stamps roles and adds them to this BotGuild.
+     * @param {CommandoClient} client 
+     * @param {Number} stampAmount 
+     * @param {Number} [stampCollectionTime]
+     * @returns {BotGuild}
+     */
+    setUpStamps(client, stampAmount, stampCollectionTime = 60) {
+        let guild = client.guilds.resolve(this.guildID);
+
+        for (let i = 0; i < stampAmount; i++) {
+            let role = await guild.roles.create({
+                data: {
+                    name: 'Stamp Role #' + i,
+                    hoist: true,
+                    color: discordServices.randomColor(),
+                }
+            });
+            this.stamps.stampRoleIDs.set(i, role.id);
+        }
+
+        this.stamps.stampCollectionTime = stampCollectionTime;
+        this.stamps.isEnabled = true;
+
+        return this;
+    }
 
 }

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -321,7 +321,7 @@ module.exports = class BotGuild {
         //     querySnapshot.docChanges().forEach(change => {
         //         if (change.type === 'added') {
         //             const embed = new Discord.MessageEmbed()
-        //                 .setColor(discordServices.colors.announcementEmbedColor)
+        //                 .setColor(botGuild.colors.announcementEmbedColor)
         //                 .setTitle('Announcement')
         //                 .setDescription(change.doc.data()['content']);
 

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -1,8 +1,30 @@
-const { Collection, Snowflake, Guild, TextChannel, Role, GuildAuditLogs } = require('discord.js');
+const { Collection, Snowflake, Guild, TextChannel, Role, GuildAuditLogs, Message, MessageEmbed } = require('discord.js');
 const { CommandoClient, CommandoGuild } = require('discord.js-commando');
 const discordServices = require('../discord-services');
 
 module.exports = class BotGuild {
+
+    
+    /**
+     * Staff role permissions.
+     * @type {String[]}
+     */
+    static staffPermissions = ['VIEW_CHANNEL', 'MANAGE_EMOJIS', 'CHANGE_NICKNAME', 'MANAGE_NICKNAMES', 
+    'KICK_MEMBERS', 'BAN_MEMBERS', 'SEND_MESSAGES', 'EMBED_LINKS', 'ATTACH_FILES', 'ADD_REACTIONS', 'USE_EXTERNAL_EMOJIS', 'MANAGE_MESSAGES', 
+    'READ_MESSAGE_HISTORY', 'CONNECT', 'STREAM', 'SPEAK', 'PRIORITY_SPEAKER', 'USE_VAD', 'MUTE_MEMBERS', 'DEAFEN_MEMBERS', 'MOVE_MEMBERS'];
+
+    /**
+     * Admin role permissions.
+     * @type {String[]}
+     */
+    static adminPermissions = ['ADMINISTRATOR'];
+
+    /**
+     * The regular member perms.
+     * @type {String[]}
+     */
+    static memberPermissions = ['VIEW_CHANNEL', 'CHANGE_NICKNAME', 'SEND_MESSAGES', 'ADD_REACTIONS', 'READ_MESSAGE_HISTORY',
+    'CONNECT', 'SPEAK', 'STREAM', 'USE_VAD'];
 
     /**
      * @typedef RoleIDs
@@ -60,158 +82,13 @@ module.exports = class BotGuild {
      * @property {ChannelIDs} channelIDs
      */
 
-
-    /**
-     * Creates a new Bot Guild.
-     * @param {String} guildID - the guild ID this new Bot Guild is associated to.
-     */
-    constructor(guildID) {
-
-        /**
-         * The Bot Guild roles
-         * @type {RoleIDs}
-         */
-        this.roleIDs = {
-            memberRole : null,
-            staffRole : null,
-            adminRole : null,
-            everyoneRole : null,
-        }
-
-        /**
-         * Permissions for important/common roles.
-         */
-        this.permissions = {
-            /**
-             * Staff role permissions.
-             * @type {String[]}
-             */
-            staffPermissions : ['VIEW_CHANNEL', 'MANAGE_EMOJIS', 'CHANGE_NICKNAME', 'MANAGE_NICKNAMES', 
-            'KICK_MEMBERS', 'BAN_MEMBERS', 'SEND_MESSAGES', 'EMBED_LINKS', 'ATTACH_FILES', 'ADD_REACTIONS', 'USE_EXTERNAL_EMOJIS', 'MANAGE_MESSAGES', 
-            'READ_MESSAGE_HISTORY', 'CONNECT', 'STREAM', 'SPEAK', 'PRIORITY_SPEAKER', 'USE_VAD', 'MUTE_MEMBERS', 'DEAFEN_MEMBERS', 'MOVE_MEMBERS'],
-            
-            /**
-             * Admin role permissions.
-             * @type {String[]}
-             */
-            adminPermissions: ['ADMINISTRATOR'],
-
-            /**
-             * The regular member perms.
-             * @type {String[]}
-             */
-            memberPermissions : ['VIEW_CHANNEL', 'CHANGE_NICKNAME', 'SEND_MESSAGES', 'ADD_REACTIONS', 'READ_MESSAGE_HISTORY',
-            'CONNECT', 'SPEAK', 'STREAM', 'USE_VAD'],
-        }
-
-        /**
-         * The common channels for this bot guild.
-         * @type {ChannelIDs}
-         */
-        this.channelIDs = {
-            adminConsole : null,
-            adminLog : null,
-            botSupportChannel : null,
-        }
-
-        /**
-         * The verification information.
-         * @type {VerificationInfo}
-         */
-        this.verification = {
-            isEnabled : false,
-            guestRoleID : null,
-            welcomeChannelID : null,
-            welcomeSupportChannelID : null,
-        }
-
-        /**
-         * The attendance information.
-         * @type {AttendanceInfo}
-         */
-        this.attendance = {
-            isEnabled : false,
-            attendeeRoleID : null,
-        }
-
-        /**
-         * The stamps information.
-         * @type {StampInfo}
-         */
-        this.stamps = {
-            isEnabled : false,
-            stampRoleIDs : new Collection(),
-            stampCollectionTime : 60,
-        }
-
-        /**
-         * The report information.
-         * @type {ReportInfo}
-         */
-        this.report = {
-            isEnabled : false,
-            incomingReportChannelID : null,
-        }
-
-        /**
-         * The announcement information.
-         * @type {AnnouncementInfo}
-         */
-        this.announcement = {
-            isEnabled : false,
-            announcementChannelID: null,
-        }
-
-        /**
-         * A list of channels where messages will get deleted after x amount of time
-         * @type {Map<Snowflake, Number>} - <text channel snowflake, Number>
-         */
-        this.blackList = new Collection();
-
-        /**
-         * All the caves this guild has active.
-         * @type {Collection<String, Cave>} - <Cave Name, Cave>
-         */
-        this.caves = new Collection();
-
-        /**
-         * All the custom colors available to the bot.
-         * @type {Object}
-         */
-        this.colors = {
-            embedColor : '#26fff4',
-            questionEmbedColor : '#f4ff26',
-            announcementEmbedColor : '#9352d9',
-            tfTeamEmbedColor : '#60c2e6',
-            tfHackerEmbedColor : '#d470cd',
-            specialDMEmbedColor : '#fc6b03',
-        }
-
-        /**
-         * The guild this Bot Guild belongs to.
-         * @type {Snowflake}
-         */
-        this.guildID = guildID;
-
-        /**
-         * The first console available to admins. Holds general bot information.
-         */
-        this.mainConsoleMsg = null;
-
-        /**
-         * True if the bot is ready and the commands are available to this guild. False otherwise.
-         * @type {Boolean}
-         */
-        this.isSetUpCompete = false;
-    }
-
     /**
      * Validate the information.
      * @param {BotGuildInfo} botGuildInfo - the information to validate
      * @throws Error if the botGuildInfo is incomplete
      */
     validateBotGuildInfo(botGuildInfo) {
-        if (typeof botGuildInfo != Object) throw new Error('The bot guild information is required!');
+        if (typeof botGuildInfo != 'object') throw new Error('The bot guild information is required!');
         if (!botGuildInfo?.roleIDs || !botGuildInfo?.roleIDs?.adminRole || !botGuildInfo?.roleIDs?.everyoneRole
             || !botGuildInfo?.roleIDs?.memberRole || !botGuildInfo?.roleIDs?.staffRole) throw new Error('All the role IDs are required!');
         if (!botGuildInfo?.channelIDs || !botGuildInfo?.channelIDs?.adminConsole || !botGuildInfo?.channelIDs?.adminLog
@@ -231,7 +108,7 @@ module.exports = class BotGuild {
         this.roleIDs = botGuildInfo.roleIDs;
         this.channelIDs = botGuildInfo.channelIDs;
 
-        let guild = await client.guilds.fetch(this.guildID);
+        let guild = await client.guilds.fetch(this._id);
 
         let adminRole = await guild.roles.fetch(this.roleIDs.adminRole);
         // try giving the admins administrator perms
@@ -249,12 +126,12 @@ module.exports = class BotGuild {
         let staffRole = await guild.roles.fetch(this.roleIDs.staffRole);
         staffRole.setMentionable(true);
         staffRole.setHoist(true);
-        staffRole.setPermissions(staffRole.permissions.add(this.permissions.staffPermissions));
+        staffRole.setPermissions(staffRole.permissions.add(BotGuild.staffPermissions));
 
         // regular member role setup
         let memberRole = await guild.roles.fetch(this.roleIDs.memberRole);
         memberRole.setMentionable(false);
-        memberRole.setPermissions(memberRole.permissions.add(this.permissions.memberPermissions));
+        memberRole.setPermissions(memberRole.permissions.add(BotGuild.memberPermissions));
 
         // change the everyone role permissions
         guild.roles.everyone.setPermissions(0); // no permissions for anything like the guest role
@@ -267,13 +144,13 @@ module.exports = class BotGuild {
                 allow: 'VIEW_CHANNEL'
             },
             {
-                id: everyoneRole.id,
+                id: this.roleIDs.everyoneRole,
                 deny: ['VIEW_CHANNEL', 'SEND_MESSAGES', 'CONNECT']
             }
         ]);
         adminCategory.children.forEach(channel => channel.lockPermissions());
 
-        this.isSetUpCompete = true;
+        this.isSetUpComplete = true;
 
         client.registry.groups.forEach((group, key, map) => {
             if (group.name.startsWith('a_')) guild.setGroupEnabled(group, true);
@@ -335,7 +212,7 @@ module.exports = class BotGuild {
      */
     async setUpVerification(client, guestRoleID, verificationChannels = null) {
         /** @type {CommandoGuild} */
-        let guild = client.guilds.fetch(this.guildID);
+        let guild = await client.guilds.fetch(this._id);
 
         try {
             var guestRole = await guild.roles.fetch(guestRoleID);
@@ -387,7 +264,7 @@ module.exports = class BotGuild {
             this.verification.welcomeSupportChannelID = welcomeChannelSupport.id;
         }
 
-        const embed = new Discord.MessageEmbed().setTitle('Welcome to the ' + guild.name + ' Discord server!')
+        const embed = new MessageEmbed().setTitle('Welcome to the ' + guild.name + ' Discord server!')
             .setDescription('In order to verify that you have registered for ' + guild.name + ', please respond to the bot (me) via DM!')
             .addField('Do you need assistance?', 'Head over to the welcome-support channel and ping the admins!')
             .setColor(this.colors.embedColor);
@@ -411,7 +288,7 @@ module.exports = class BotGuild {
         this.attendance.attendeeRoleID = attendeeRoleID;
         this.attendance.isEnabled = true;
         /** @type {CommandoGuild} */
-        let guild = await client.guilds.fetch(this.guildID);
+        let guild = await client.guilds.fetch(this._id);
         guild.setCommandEnabled('start-attend', true);
         return this;
     }
@@ -420,10 +297,11 @@ module.exports = class BotGuild {
      * Will set up the firebase announcements.
      * @param {CommandoClient} client 
      * @param {String} announcementChannelID
+     * @async
      */
-    setUpAnnouncements(client, announcementChannelID) {
+    async setUpAnnouncements(client, announcementChannelID) {
         /** @type {CommandoGuild} */
-        let guild = client.guilds.fetch(this.guildID);
+        let guild = await client.guilds.fetch(this._id);
         
         let announcementChannel = guild.channels.resolve(announcementChannelID);
         if (!announcementChannel) throw new Error('The announcement channel ID is not valid for this guild!');
@@ -464,11 +342,11 @@ module.exports = class BotGuild {
      * @async
      */
     async setUpStamps(client, stampAmount = 0, stampCollectionTime = 60, stampRoleIDs = []) {
-        let guild = client.guilds.fetch(this.guildID);
+        let guild = await client.guilds.fetch(this._id);
 
-        if (stampRoleIDs) {
+        if (stampRoleIDs.length > 0) {
             stampRoleIDs.forEach((ID, index, array) => {
-                discordServices.stampRoles.set(index, ID);
+                this.stamps.stampRoleIDs.set(index.toString(), ID);
             });
         } else {
             for (let i = 0; i < stampAmount; i++) {
@@ -479,7 +357,7 @@ module.exports = class BotGuild {
                         color: discordServices.randomColor(),
                     }
                 });
-                this.stamps.stampRoleIDs.set(i, role.id);
+                this.stamps.stampRoleIDs.set(i.toString(), role.id);
             }
         }
 
@@ -493,11 +371,12 @@ module.exports = class BotGuild {
      * Enables the report commands and sends the reports to the given channel.
      * @param {CommandoClient} client 
      * @param {String} incomingReportChannelID 
-     * @returns {BotGuild}
+     * @returns {Promise<BotGuild>}
+     * @async
      */
-    setUpReport(client, incomingReportChannelID) {
+    async setUpReport(client, incomingReportChannelID) {
         /** @type {CommandoGuild} */
-        let guild = client.guilds.fetch(this.guildID);
+        let guild = await client.guilds.fetch(this._id);
 
         this.report.isEnabled = true;
         this.report.incomingReportChannelID = incomingReportChannelID;
@@ -511,10 +390,9 @@ module.exports = class BotGuild {
      * Will enable the ask command.
      * @param {CommandoClient} client 
      */
-    setUpAsk(client) {
+    async setUpAsk(client) {
         /** @type {CommandoGuild} */
-        let guild = client.guilds.fetch(this.guildID);
+        let guild = await client.guilds.fetch(this._id);
         guild.setCommandEnabled('ask', true);
     }
-
 }

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -1,5 +1,5 @@
-const { Collection, Snowflake, Guild, TextChannel, Role } = require('discord.js');
-const { CommandoClient } = require('discord.js-commando');
+const { Collection, Snowflake, Guild, TextChannel, Role, GuildAuditLogs } = require('discord.js');
+const { CommandoClient, CommandoGuild } = require('discord.js-commando');
 
 module.exports = class BotGuild {
 
@@ -301,6 +301,7 @@ module.exports = class BotGuild {
      * @return {BotGuild}
      */
     setUpVerification(client, guestRoleID) {
+        /** @type {CommandoGuild} */
         let guild = client.guilds.resolve(this.guildID);
 
         try {
@@ -350,7 +351,23 @@ module.exports = class BotGuild {
         this.verification.welcomeChannelID = welcomeChannel.id;
         this.verification.welcomeSupportChannelID = welcomeChannelSupport.id;
         this.verification.isEnabled = true;
+        guild.setCommandEnabled('verify', true);
 
+        return this;
+    }
+
+    /**
+     * Sets up the attendance functionality.
+     * @param {CommandoClient} client 
+     * @param {String} attendeeRoleID
+     * @returns {BotGuild}
+     */
+    setUpAttendance(client, attendeeRoleID) {
+        this.attendance.attendeeRoleID = attendeeRoleID;
+        this.attendance.isEnabled = true;
+        /** @type {CommandoGuild} */
+        let guild = await client.guilds.fetch(this.guildID);
+        guild.setCommandEnabled('start-attend', true);
         return this;
     }
 

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -48,6 +48,12 @@ module.exports = class BotGuild {
      */
 
     /**
+     * @typedef AnnouncementInfo
+     * @property {Boolean} isEnabled
+     * @property {String} announcementChannelID
+     */
+
+    /**
      * @typedef BotGuildInfo
      * @property {RoleIDs} roleIDs
      * @property {ChannelIDs} channelIDs
@@ -144,6 +150,15 @@ module.exports = class BotGuild {
         this.report = {
             isEnabled : false,
             incomingReportChannelID : null,
+        }
+
+        /**
+         * The announcement information.
+         * @type {AnnouncementInfo}
+         */
+        this.announcement = {
+            isEnabled : false,
+            announcementChannelID: null,
         }
 
         /**
@@ -370,5 +385,44 @@ module.exports = class BotGuild {
         guild.setCommandEnabled('start-attend', true);
         return this;
     }
+
+    /**
+     * Will set up the firebase announcements.
+     * @param {CommandoClient} client 
+     * @param {String} announcementChannelID
+     */
+    setUpAnnouncements(client, announcementChannelID) {
+        /** @type {CommandoGuild} */
+        let guild = client.guilds.fetch(this.guildID);
+        
+        let announcementChannel = guild.channels.resolve(announcementChannelID);
+        if (!announcementChannel) throw new Error('The announcement channel ID is not valid for this guild!');
+
+        this.announcement.isEnabled = true;
+        this.announcement.announcementChannelID = announcementChannelID;
+
+        // TODO Firebase setup 
+        // start query listener for announcements
+        // nwFirebase.firestore().collection('Hackathons').doc('nwHacks2021').collection('Announcements').onSnapshot(querySnapshot => {
+        //     // exit if we are at the initial state
+        //     if (isInitState) {
+        //         isInitState = false;
+        //         return;
+        //     }
+
+        //     querySnapshot.docChanges().forEach(change => {
+        //         if (change.type === 'added') {
+        //             const embed = new Discord.MessageEmbed()
+        //                 .setColor(discordServices.colors.announcementEmbedColor)
+        //                 .setTitle('Announcement')
+        //                 .setDescription(change.doc.data()['content']);
+
+        //             announcementChannel.send('<@&' + discordServices.roleIDs.attendeeRole + '>', { embed: embed });
+        //         }
+        //     });
+        // });
+    }
+
+    
 
 }

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -451,4 +451,22 @@ module.exports = class BotGuild {
         return this;
     }
 
+    /**
+     * Enables the report commands and sends the reports to the given channel.
+     * @param {CommandoClient} client 
+     * @param {String} incomingReportChannelID 
+     * @returns {BotGuild}
+     */
+    setUpReport(client, incomingReportChannelID) {
+        /** @type {CommandoGuild} */
+        let guild = client.guilds.resolve(this.guildID);
+
+        this.report.isEnabled = true;
+        this.report.incomingReportChannelID = incomingReportChannelID;
+
+        guild.setCommandEnabled('report', true);
+
+        return this;
+    }
+
 }

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -225,7 +225,7 @@ module.exports = class BotGuild {
      * @returns {BotGuild}
      * @async
      */
-    async readyUp(botGuildInfo, client) {
+    async readyUp(client, botGuildInfo) {
         this.validateBotGuildInfo(botGuildInfo);
 
         this.roleIDs = botGuildInfo.roleIDs;
@@ -274,6 +274,10 @@ module.exports = class BotGuild {
         adminCategory.children.forEach(channel => channel.lockPermissions());
 
         this.isSetUpCompete = true;
+
+        client.registry.groups.forEach((group, key, map) => {
+            if (group.name.startsWith('a_')) guild.setGroupEnabled(group, true);
+        });
 
         return this;
     }

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -1,0 +1,176 @@
+const { Collection, Snowflake } = require('discord.js');
+
+module.exports = class BotGuild {
+
+    /**
+     * @typedef RoleIDs
+     * @property {String} memberRole - regular guild member role ID
+     * @property {String} staffRole - the staff role ID
+     * @property {String} adminRole - the admin role ID
+     * @property {String} everyoneRole - the everyone role ID
+     */
+
+     /**
+      * @typedef ChannelIDs
+      * @property {String} adminConsole - the admin console channel ID
+      * @property {String} adminLog - the admin log channel ID
+      * @property {String} botSupportChannel - the bot support channel ID
+      */
+
+    /**
+     * @typedef VerificationInfo
+     * @property {Boolean} isEnabled - true if verification is enabled
+     * @property {String} isVerifiedRoleID - the verified role ID that holds basic permissions
+     * @property {String[]} isVerifiedRolePermissions - the permissions for the isVerified role
+     * @property {String} guestRoleID - the guest role ID used for verification
+     * @property {String} welcomeChannelID -  the welcome channel where users learn to verify
+     * @property {String} welcomeSupportChannelID - the support channel where the bot can contact users
+     */
+
+    /**
+     * @typedef AttendanceInfo
+     * @property {Boolean} isEnabled - true if attendance is enabled in this guild
+     * @property {String} attendeeRoleID - the attendee role ID used for attendance
+     */
+
+    /**
+     * @typedef StampInfo
+     * @property {Boolean} isEnabled - true if stamps are enabled
+     * @property {Collection<Number, String>} stampRoleIDs - <StampNumber, roleID>
+     * @property {Number} stampCollectionTime - time given to users to collect password stamps
+     */
+
+    /**
+     * @typedef ReportInfo
+     * @property {Boolean} isEnabled - true if the report functionality is enabled
+     * @property {String} incomingReportChannelID - channel where reports are sent
+     */
+
+    /**
+     * Creates a new Bot Guild.
+     * @param {String} guildID - the guild ID this new Bot Guild is associated to.
+     */
+    constructor(guildID) {
+
+        /**
+         * The Bot Guild roles
+         * @type {RoleIDs}
+         */
+        this.roleIDs = {
+            memberRole : null,
+            staffRole : null,
+            adminRole : null,
+            everyoneRole : null,
+        }
+
+        /**
+         * Permissions for important/common roles.
+         */
+        this.permissions = {
+            /**
+             * Staff role permissions.
+             * @type {String[]}
+             */
+            staffPermissions : ['VIEW_CHANNEL', 'MANAGE_EMOJIS', 'CHANGE_NICKNAME', 'MANAGE_NICKNAMES', 
+            'KICK_MEMBERS', 'BAN_MEMBERS', 'SEND_MESSAGES', 'EMBED_LINKS', 'ATTACH_FILES', 'ADD_REACTIONS', 'USE_EXTERNAL_EMOJIS', 'MANAGE_MESSAGES', 
+            'READ_MESSAGE_HISTORY', 'CONNECT', 'STREAM', 'SPEAK', 'PRIORITY_SPEAKER', 'USE_VAD', 'MUTE_MEMBERS', 'DEAFEN_MEMBERS', 'MOVE_MEMBERS'],
+            
+            /**
+             * Admin role permissions.
+             * @type {String[]}
+             */
+            adminPermissions: ['ADMINISTRATOR'],
+        }
+
+        /**
+         * The common channels for this bot guild.
+         * @type {ChannelIDs}
+         */
+        this.channelIDs = {
+            adminConsole : null,
+            adminLog : null,
+            botSupportChannel : null,
+        }
+
+        /**
+         * The verification information.
+         * @type {VerificationInfo}
+         */
+        this.verification = {
+            isEnabled : false,
+            isVerifiedRoleID : null,
+            isVerifiedRolePermissions : ['VIEW_CHANNEL', 'CHANGE_NICKNAME', 'SEND_MESSAGES', 'ADD_REACTIONS', 'READ_MESSAGE_HISTORY',
+            'CONNECT', 'SPEAK', 'STREAM', 'USE_VAD'],
+            guestRoleID : null,
+            welcomeChannelID : null,
+            welcomeSupportChannelID : null,
+        }
+
+        /**
+         * The attendance information.
+         * @type {AttendanceInfo}
+         */
+        this.attendance = {
+            isEnabled : false,
+            attendeeRoleID : null,
+        }
+
+        /**
+         * The stamps information.
+         * @type {StampInfo}
+         */
+        this.stamps = {
+            isEnabled : false,
+            stampRoleIDs : new Collection(),
+            stampCollectionTime : 60,
+        }
+
+        /**
+         * The report information.
+         * @type {ReportInfo}
+         */
+        this.report = {
+            isEnabled : false,
+            incomingReportChannelID : null,
+        }
+
+        /**
+         * A list of channels where messages will get deleted after x amount of time
+         * @type {Map<Snowflake, Number>} - <text channel snowflake, Number>
+         */
+        this.blackList = new Collection();
+
+        /**
+         * All the caves this guild has active.
+         * @type {Collection<String, Cave>} - <Cave Name, Cave>
+         */
+        this.caves = new Collection();
+
+        /**
+         * All the custom colors available to the bot.
+         * @type {Object}
+         */
+        this.colors = {
+            embedColor : '#26fff4',
+            questionEmbedColor : '#f4ff26',
+            announcementEmbedColor : '#9352d9',
+            tfTeamEmbedColor : '#60c2e6',
+            tfHackerEmbedColor : '#d470cd',
+            specialDMEmbedColor : '#fc6b03',
+        }
+
+        /**
+         * The guild this Bot Guild belongs to.
+         * @type {Snowflake}
+         */
+        this.guildID = guildID
+
+        /**
+         * The first console available to admins. Holds general bot information.
+         */
+        this.mainConsoleMsg;
+
+    }
+
+
+}

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -477,4 +477,14 @@ module.exports = class BotGuild {
         return this;
     }
 
+    /**
+     * Will enable the ask command.
+     * @param {CommandoClient} client 
+     */
+    setUpAsk(client) {
+        /** @type {CommandoGuild} */
+        let guild = client.guilds.fetch(this.guildID);
+        guild.setCommandEnabled('ask', true);
+    }
+
 }

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -222,8 +222,10 @@ module.exports = class BotGuild {
      * Will set the minimum required information for the bot to work on this guild.
      * @param {BotGuildInfo} botGuildInfo 
      * @param {CommandoClient} client
+     * @returns {BotGuild}
+     * @async
      */
-    readyUp(botGuildInfo, client) {
+    async readyUp(botGuildInfo, client) {
         this.validateBotGuildInfo(botGuildInfo);
 
         this.roleIDs = botGuildInfo.roleIDs;
@@ -272,6 +274,8 @@ module.exports = class BotGuild {
         adminCategory.children.forEach(channel => channel.lockPermissions());
 
         this.isSetUpCompete = true;
+
+        return this;
     }
 
     /**
@@ -281,6 +285,7 @@ module.exports = class BotGuild {
      * @param {Role} everyoneRole 
      * @returns {Promise<{TextChannel, TextChannel}>} - {Admin Console, Admin Log Channel}
      * @static
+     * @async
      */
     static async createAdminChannels(guild, adminRole, everyoneRole) {
         let adminCategory = await guild.channels.create('Admins', {
@@ -315,10 +320,11 @@ module.exports = class BotGuild {
      * @param {CommandoClient} client 
      * @param {String} guestRoleID
      * @return {BotGuild}
+     * @async
      */
-    setUpVerification(client, guestRoleID) {
+    async setUpVerification(client, guestRoleID) {
         /** @type {CommandoGuild} */
-        let guild = client.guilds.resolve(this.guildID);
+        let guild = client.guilds.fetch(this.guildID);
 
         try {
             var guestRole = await guild.roles.fetch(guestRoleID);
@@ -377,8 +383,9 @@ module.exports = class BotGuild {
      * @param {CommandoClient} client 
      * @param {String} attendeeRoleID
      * @returns {BotGuild}
+     * @async
      */
-    setUpAttendance(client, attendeeRoleID) {
+    async setUpAttendance(client, attendeeRoleID) {
         this.attendance.attendeeRoleID = attendeeRoleID;
         this.attendance.isEnabled = true;
         /** @type {CommandoGuild} */
@@ -429,10 +436,11 @@ module.exports = class BotGuild {
      * @param {CommandoClient} client 
      * @param {Number} stampAmount 
      * @param {Number} [stampCollectionTime]
-     * @returns {BotGuild}
+     * @returns {Promise<BotGuild>}
+     * @async
      */
-    setUpStamps(client, stampAmount, stampCollectionTime = 60) {
-        let guild = client.guilds.resolve(this.guildID);
+    async setUpStamps(client, stampAmount, stampCollectionTime = 60) {
+        let guild = client.guilds.fetch(this.guildID);
 
         for (let i = 0; i < stampAmount; i++) {
             let role = await guild.roles.create({
@@ -459,7 +467,7 @@ module.exports = class BotGuild {
      */
     setUpReport(client, incomingReportChannelID) {
         /** @type {CommandoGuild} */
-        let guild = client.guilds.resolve(this.guildID);
+        let guild = client.guilds.fetch(this.guildID);
 
         this.report.isEnabled = true;
         this.report.incomingReportChannelID = incomingReportChannelID;

--- a/classes/cave.js
+++ b/classes/cave.js
@@ -2,7 +2,7 @@ const Discord = require("discord.js");
 const discordServices = require('../discord-services');
 const Prompt = require('../classes/prompt');
 const Ticket = require('../classes/ticket');
-const { messagePrompt } = require("../classes/prompt");
+const BotGuild = require("../db/botGuildDBObject");
 
 class Cave {
 
@@ -208,12 +208,14 @@ class Cave {
      * @async
      */
     async initPrivate(guildChannelManager) {
+        let botGuild = await BotGuild.findById(guildChannelManager.guild.id);
+
         // Create category
         this.privateChannels.category = await guildChannelManager.create(this.caveOptions.preEmojis + this.caveOptions.name + ' Cave', {
             type: 'category',  
             permissionOverwrites: [
                 {
-                    id: discordServices.roleIDs.everyoneRole,
+                    id: botGuild.roleIDs.everyoneRole,
                     deny: ['VIEW_CHANNEL']
                 },
                 {
@@ -222,7 +224,7 @@ class Cave {
                     deny: ['SEND_MESSAGES'],
                 },
                 {
-                    id: discordServices.roleIDs.staffRole,
+                    id: botGuild.roleIDs.staffRole,
                     allow: ['VIEW_CHANNEL'],
                 }
             ]

--- a/classes/permission-command.js
+++ b/classes/permission-command.js
@@ -1,5 +1,6 @@
 const Discord = require('discord.js');
 const { Command } = require('discord.js-commando');
+const BotGuild = require('../db/botGuildDBObject');
 const discordServices = require('../discord-services');
 
 
@@ -65,6 +66,8 @@ class PermissionCommand extends Command {
         // delete the message
         discordServices.deleteMessage(message);
 
+        let botGuild = await BotGuild.findById(message.guild.id);
+
         // check for DM only, when true, all other checks should not happen!
         if (this.permissionInfo.dmOnly) {
             if (message.channel.type != 'dm') {
@@ -87,12 +90,12 @@ class PermissionCommand extends Command {
             // Make sure only the permitted role can call it
             else if (this.permissionInfo?.role) {
 
-                let roleID = discordServices.roleIDs[this.permissionInfo.role];
+                let roleID = botGuild.roleIDs[this.permissionInfo.role];
 
                 // if staff role then check for staff and admin, else check the given role
-                if (roleID && (roleID === discordServices.roleIDs.staffRole && 
-                    (!discordServices.checkForRole(message.member, roleID) && !discordServices.checkForRole(message.member, discordServices.roleIDs.adminRole))) || 
-                    (roleID != discordServices.roleIDs.staffRole && !discordServices.checkForRole(message.member, roleID))) {
+                if (roleID && (roleID === botGuild.roleIDs.staffRole && 
+                    (!discordServices.checkForRole(message.member, roleID) && !discordServices.checkForRole(message.member, botGuild.roleIDs.adminRole))) || 
+                    (roleID != botGuild.roleIDs.staffRole && !discordServices.checkForRole(message.member, roleID))) {
                         discordServices.sendMessageToMember(message.member, this.permissionInfo.roleMessage, true);
                         return;
                 }

--- a/classes/prompt.js
+++ b/classes/prompt.js
@@ -18,7 +18,7 @@ class Prompt {
      * Prompt the user for some text.
      * @param {PromptInfo} promptInfo - the common data, prompt, channel, userId
      * @param {String} responseType - the type of response, one of string, number, boolean, mention
-     * @param {Number} time - the time in seconds to wait for the response, if 0 then wait forever
+     * @param {Number} [time] - the time in seconds to wait for the response, if 0 then wait forever
      * @returns {Promise<Message>} - the message response to the prompt or false if it timed out!
      * @throws Will throw an error if the user cancels the Prompt or it times out. Name: Cancel or Timeout
      * @async
@@ -83,7 +83,7 @@ class Prompt {
     /**
      * Prompts the user to respond to a message with an emoji.
      * @param {PromptInfo} promptInfo - the common data, prompt, channel, userId
-     * @param {Collection<String, Emoji>} unavailableEmojis - <emoji name, emoji>, the emojis the user can't select, re-prompt if necessary
+     * @param {Collection<String, Emoji>} [unavailableEmojis] - <emoji name, emoji>, the emojis the user can't select, re-prompt if necessary
      * @async
      * @returns {Promise<GuildEmoji | ReactionEmoji>} - the message reaction
      */

--- a/classes/team-formation.js
+++ b/classes/team-formation.js
@@ -1,6 +1,7 @@
 const { GuildEmoji, ReactionEmoji, Role, TextChannel, MessageEmbed, Guild, GuildChannelManager, User, Message, RoleManager } = require('discord.js');
 const { messagePrompt } = require('./prompt');
 const discordServices = require('../discord-services');
+const BotGuild = require('../db/botGuildDBObject');
 
 /**
  * @class TeamFormation
@@ -207,7 +208,7 @@ module.exports = class TeamFormation {
             embed = signupEmbedCreator(this.teamInfo.emoji, this.prospectInfo.emoji, this.isNotificationEnabled);
         } else {
             embed = new MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor((await (BotGuild.findById(this.guild.id))).colors.embedColor)
             .setTitle('Team Formation Information')
             .setDescription('Welcome to the team formation section! If you are looking for a team or need a few more members to complete your ultimate group, you are in the right place!')
             .addField('How does this work?', '* Once you react to this message, I will send you a template you need to fill out and send back to me via DM. \n* Then I will post your information in the channels below. \n* Then, other members, teams, or yourself can browse these channels and reach out via DM!')

--- a/classes/ticket.js
+++ b/classes/ticket.js
@@ -1,5 +1,6 @@
 const { Collection } = require("discord.js");
 const Discord = require("discord.js");
+const BotGuild = require("../db/botGuildDBObject");
 const discordServices = require('../discord-services');
 const Cave = require("./cave");
 
@@ -159,7 +160,7 @@ class Ticket {
             type: 'category',
             permissionOverwrites: [
                 {
-                    id: discordServices.roleIDs.everyoneRole,
+                    id: (await BotGuild.findById(this.guild.id)).roleIDs.everyoneRole,
                     deny: ['VIEW_CHANNEL'],
                 }
             ]
@@ -192,7 +193,7 @@ class Ticket {
 
         // if ticket has not been accepted after the specified time, it will send a reminder to the incoming tickets channel tagging all mentors
         var timeout = setTimeout(() => {
-            this.cave.privateChannels.incomingTickets.send('Hello <@&' + discordServices.roleIDs.mentorRole + '> ticket number ' + this.ticketNumber + ' still needs help!');
+            this.cave.privateChannels.incomingTickets.send('Hello <@&' + this.cave.caveOptions.role + '> ticket number ' + this.ticketNumber + ' still needs help!');
         }, this.cave.caveOptions.times.reminderTime * 60 * 1000);
 
         // let user know that ticket was submitted and give option to remove ticket

--- a/classes/ticket.js
+++ b/classes/ticket.js
@@ -160,7 +160,7 @@ class Ticket {
             type: 'category',
             permissionOverwrites: [
                 {
-                    id: (await BotGuild.findById(this.guild.id)).roleIDs.everyoneRole,
+                    id: this.cave.botGuild.roleIDs.everyoneRole,
                     deny: ['VIEW_CHANNEL'],
                 }
             ]

--- a/commands/a_activity/add-voice-channels.js
+++ b/commands/a_activity/add-voice-channels.js
@@ -39,7 +39,7 @@ module.exports = class CreatePrivatesFor extends ActivityCommand {
      * @param {Message} message 
      * @param {Activity} activity 
      */
-    async activityCommand(message, activity, {number, isPrivate, maxUsers}) {
+    async activityCommand(botGuild, message, activity, {number, isPrivate, maxUsers}) {
         let final = activity.addVoiceChannels(number, isPrivate, maxUsers);
 
         // report success of workshop creation

--- a/commands/a_activity/archive.js
+++ b/commands/a_activity/archive.js
@@ -23,10 +23,8 @@ module.exports = class InitAmongUs extends ActivityCommand {
      * @param {Message} message 
      * @param {Activity} activity 
      */
-    async activityCommand(message, activity) {
-
-        let botGuild = await BotGuild.findById(message.guild.id);
-
+    async activityCommand(botGuild, message, activity) {
+        
         // get the archive category or create it
         var archiveCategory = await message.guild.channels.cache.find(channel => channel.type === 'category' && channel.name === '💼archive');
 
@@ -37,13 +35,13 @@ module.exports = class InitAmongUs extends ActivityCommand {
             archiveCategory = await message.guild.channels.create('💼archive', {
                 type: 'category', 
                 position: position + 1,
-                permissionOverwrites: botGuild.roleIDs?.attendeeRole ? [
+                permissionOverwrites: botGuild.attendance.isEnabled ? [
                     {
                         id: botGuild.roleIDs.everyoneRole,
                         deny: ['VIEW_CHANNEL'],
                     },
                     {
-                        id: botGuild.roleIDs.attendeeRole,
+                        id: botGuild.attendance.attendeeRoleID,
                         allow: ['VIEW_CHANNEL'],
                     },
                     {

--- a/commands/a_activity/archive.js
+++ b/commands/a_activity/archive.js
@@ -1,7 +1,9 @@
 // Discord.js commando requirements
 const Activity = require('../../classes/activity');
 const ActivityCommand = require('../../classes/activity-command');
+const BotGuild = require('../../db/botGuildDBObject');
 const discordServices = require('../../discord-services');
+const { Message } = require('discord.js');
 
 
 // Command export
@@ -23,6 +25,8 @@ module.exports = class InitAmongUs extends ActivityCommand {
      */
     async activityCommand(message, activity) {
 
+        let botGuild = await BotGuild.findById(message.guild.id);
+
         // get the archive category or create it
         var archiveCategory = await message.guild.channels.cache.find(channel => channel.type === 'category' && channel.name === '💼archive');
 
@@ -33,17 +37,17 @@ module.exports = class InitAmongUs extends ActivityCommand {
             archiveCategory = await message.guild.channels.create('💼archive', {
                 type: 'category', 
                 position: position + 1,
-                permissionOverwrites: discordServices.roleIDs?.memberRole ? [
+                permissionOverwrites: botGuild.roleIDs?.attendeeRole ? [
                     {
-                        id: discordServices.roleIDs.everyoneRole,
+                        id: botGuild.roleIDs.everyoneRole,
                         deny: ['VIEW_CHANNEL'],
                     },
                     {
-                        id: discordServices.roleIDs.memberRole,
+                        id: botGuild.roleIDs.attendeeRole,
                         allow: ['VIEW_CHANNEL'],
                     },
                     {
-                        id: discordServices.roleIDs.staffRole,
+                        id: botGuild.roleIDs.staffRole,
                         allow: ['VIEW_CHANNEL'],
                     }
                 ] : []

--- a/commands/a_activity/callback.js
+++ b/commands/a_activity/callback.js
@@ -22,7 +22,7 @@ module.exports = class ActivityCallback extends ActivityCommand {
      * @param {Message} message - the message that has the command
      * @param {Activity} activity - the activity for this activity command
      */
-    async activityCommand(message, activity, args, fromPattern, result) {
+    async activityCommand(botGuild, message, activity, args, fromPattern, result) {
 
         ActivityManager.voiceCallBack(activity);
 

--- a/commands/a_activity/discord-contests.js
+++ b/commands/a_activity/discord-contests.js
@@ -41,6 +41,7 @@ module.exports = class DiscordContests extends PermissionCommand {
         // helpful prompt vars
         let channel = message.channel;
         let userId = message.author.id;
+        this.botGuild = botGuild;
 
         //ask user for time interval between questions
         var timeInterval;
@@ -80,7 +81,7 @@ module.exports = class DiscordContests extends PermissionCommand {
         }
 
         const startEmbed = new Discord.MessageEmbed()
-            .setColor(botGuild.colors.embedColor)
+            .setColor(this.botGuild.colors.embedColor)
             .setTitle(string)
             .setDescription('Note: Questions that have correct answers are non-case sensitive but any extra or missing symbols will be considered incorrect.\n' +
                 'For Staff only:\n' +
@@ -144,7 +145,7 @@ module.exports = class DiscordContests extends PermissionCommand {
             let needAllAnswers = data.needAllAnswers;
 
             const qEmbed = new Discord.MessageEmbed()
-                .setColor(botGuild.colors.embedColor)
+                .setColor(this.botGuild.colors.embedColor)
                 .setTitle('A new Discord Contest Question:')
                 .setDescription(question + '\n' + ((answers.length === 0) ? 'Staff: click the 👑 emoji to announce a winner!' : 
                                                                             'Exact answers only!'));

--- a/commands/a_activity/discord-contests.js
+++ b/commands/a_activity/discord-contests.js
@@ -3,7 +3,8 @@ const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const { numberPrompt, yesNoPrompt, rolePrompt, memberPrompt } = require('../../classes/prompt');
 const { getQuestion } = require('../../firebase-services/firebase-services');
-const BotGuild = require('../../db/botGuildDBObject');
+const { Document } = require('mongoose');
+
 
 var interval;
 
@@ -33,14 +34,13 @@ module.exports = class DiscordContests extends PermissionCommand {
      * Stores a map which keeps the questions (strings) as keys and an array of possible answers (strings) as values. It iterates through
      * each key in order and asks them in the Discord channel in which it was called at the given intervals. It also listens for emojis
      * that tell it to pause, resume, or remove a specified question. 
+     * @param {Document} botGuild
      * @param {Discord.Message} message - the message in which this command was called
      */
-    async runCommand(message) {
+    async runCommand(botGuild, message) {
         // helpful prompt vars
         let channel = message.channel;
         let userId = message.author.id;
-        
-        this.botGuild = await BotGuild.findById(message.guild.id);
 
         //ask user for time interval between questions
         var timeInterval;
@@ -80,7 +80,7 @@ module.exports = class DiscordContests extends PermissionCommand {
         }
 
         const startEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle(string)
             .setDescription('Note: Questions that have correct answers are non-case sensitive but any extra or missing symbols will be considered incorrect.\n' +
                 'For Staff only:\n' +
@@ -144,7 +144,7 @@ module.exports = class DiscordContests extends PermissionCommand {
             let needAllAnswers = data.needAllAnswers;
 
             const qEmbed = new Discord.MessageEmbed()
-                .setColor(discordServices.colors.embedColor)
+                .setColor(botGuild.colors.embedColor)
                 .setTitle('A new Discord Contest Question:')
                 .setDescription(question + '\n' + ((answers.length === 0) ? 'Staff: click the 👑 emoji to announce a winner!' : 
                                                                             'Exact answers only!'));

--- a/commands/a_activity/distribute-stamp.js
+++ b/commands/a_activity/distribute-stamp.js
@@ -15,7 +15,7 @@ module.exports = class DistributeStamp extends PermissionCommand {
                     key: 'timeLimit',
                     prompt: 'How many seconds will the reactions be open for',
                     type: 'integer',
-                    default: discordServices.stampCollectTime,
+                    default: 60,
                 },
             ],
         },
@@ -30,7 +30,7 @@ module.exports = class DistributeStamp extends PermissionCommand {
      * @param {Message} message 
      * @param {Activity} activity 
      */
-    async runCommand(message, activity, {timeLimit}) {
+    async runCommand(botGuild, message, activity, {timeLimit}) {
         ActivityManager.distributeStamp(activity, timeLimit);
     }
 };

--- a/commands/a_activity/distribute-stamp.js
+++ b/commands/a_activity/distribute-stamp.js
@@ -31,6 +31,6 @@ module.exports = class DistributeStamp extends PermissionCommand {
      * @param {Activity} activity 
      */
     async runCommand(botGuild, message, activity, {timeLimit}) {
-        ActivityManager.distributeStamp(activity, timeLimit);
+        ActivityManager.distributeStamp(activity, botGuild, timeLimit);
     }
 };

--- a/commands/a_activity/hide-unhide.js
+++ b/commands/a_activity/hide-unhide.js
@@ -37,10 +37,6 @@ module.exports = class HideUnhide extends Command {
         discordServices.deleteMessage(message);
 
         // make sure command is only used in the admin console
-        if (! (await discordServices.isAdminConsole(message.channel))) {
-            discordServices.replyAndDelete(message, 'This command can only be used in the admin console!');
-            return;   
-        }
         // only members with the staff tag can run this command!
         if (!(discordServices.checkForRole(message.member, discordServices.roleIDs.staffRole))) {
             discordServices.replyAndDelete(message, 'You do not have permission for this command, only staff can use it!');

--- a/commands/a_activity/hide-unhide.js
+++ b/commands/a_activity/hide-unhide.js
@@ -37,7 +37,7 @@ module.exports = class HideUnhide extends Command {
         discordServices.deleteMessage(message);
 
         // make sure command is only used in the admin console
-        if (! discordServices.isAdminConsole(message.channel)) {
+        if (! (await discordServices.isAdminConsole(message.channel))) {
             discordServices.replyAndDelete(message, 'This command can only be used in the admin console!');
             return;   
         }

--- a/commands/a_activity/init-among-us.js
+++ b/commands/a_activity/init-among-us.js
@@ -31,7 +31,7 @@ module.exports = class InitAmongUs extends ActivityCommand {
      * @param {Message} message - the message that has the command
      * @param {Activity} activity - the activity for this activity command
      */
-    async activityCommand(message, activity, { numOfChannels}) {
+    async activityCommand(botGuild, message, activity, { numOfChannels}) {
 
         let joinActivityTextChannel = await activity.makeAmongUs(numOfChannels);
 
@@ -40,7 +40,7 @@ module.exports = class InitAmongUs extends ActivityCommand {
 
         // send embed and react with emoji
         const msgEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('Join the activity!')
             .setDescription('Welcome to the Among Us Mini-Event. We have set up some voice channels for hackers to meet each other and play some Among Us. Here is how its going to work:\n' +
             '1. Accept rules listed below by clicking the 🚗 emoji.\n' +

--- a/commands/a_activity/init-coffee-chats.js
+++ b/commands/a_activity/init-coffee-chats.js
@@ -29,7 +29,7 @@ module.exports = class InitCoffeeChats extends ActivityCommand {
      * @param {Message} message - the message that has the command
      * @param {Activity} activity - the activity for this activity command
      */
-    async activityCommand(message, activity, { numOfGroups }) {
+    async activityCommand(botGuild, message, activity, { numOfGroups }) {
 
         let joinActivityChannel = await activity.makeCoffeeChats(numOfGroups);
 
@@ -38,7 +38,7 @@ module.exports = class InitCoffeeChats extends ActivityCommand {
 
         // send embed and react with emoji
         const msgEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('Join the activity!')
             .setDescription('If you want to join this activity, please react to this message with ' + emoji +' and follow my instructions!\n If the emojis are not working' +
             ' it means the activity is full. Check the activity text channel for other activity times!');

--- a/commands/a_activity/init-workshop.js
+++ b/commands/a_activity/init-workshop.js
@@ -22,9 +22,7 @@ module.exports = class InitWorkshop extends ActivityCommand {
      * @param {Discord.Message} message - the message that has the command
      * @param {Activity} activity - the activity for this activity command
      */
-    async activityCommand(message, activity) {
-
-        let botGuild = await BotGuild.findById(message.guild.id);
+    async activityCommand(botGuild, message, activity) {
 
         let channels = await activity.makeWorkshop();
 
@@ -65,7 +63,7 @@ module.exports = class InitWorkshop extends ActivityCommand {
                 // let TAs know about the change!
                 taChannel.send('Low tech solution has been turned on!').then(msg => msg.delete({timeout: 5000}));
                 msg.edit(msg.embeds[0].addField('Low Tech Solution Is On', 'To give assistance: \n* Send a DM to the highers member on the wait list \n* Then click on the emoji to remove them from the list!'));
-                helpChannel.send(new Discord.MessageEmbed().setColor(discordServices.colors.embedColor).setTitle('Quick Update!').setDescription('You do not need to join the ' +  activity.activityInfo.generalVoiceChannelName + ' voice channel. TAs will send you a DM when they are ready to assist you!'));
+                helpChannel.send(new Discord.MessageEmbed().setColor(botGuild.colors.embedColor).setTitle('Quick Update!').setDescription('You do not need to join the ' +  activity.activityInfo.generalVoiceChannelName + ' voice channel. TAs will send you a DM when they are ready to assist you!'));
             });
         });
         
@@ -73,7 +71,7 @@ module.exports = class InitWorkshop extends ActivityCommand {
             .setColor(mentorColor)
             .setTitle('Polling and Stamp Console')
             .setDescription('Here are some common polls you might want to use!')
-            .addField('Stamp Distribution', '📇 Will activate a stamp distribution that will be open for ' + discordServices.stampCollectTime + ' seconds.')
+            .addField('Stamp Distribution', '📇 Will activate a stamp distribution that will be open for ' + botGuild.stamps.stampCollectionTime + ' seconds.')
             .addField('Speed Poll', '🏎️ Will send an embedded message asking how the speed is.')
             .addField('Difficulty Poll', '🎓 Will send an embedded message asking how the difficulty is.')
             .addField('Explanation Poll', '🧑‍🏫 Will send an embedded message asking how good the explanations are.');
@@ -98,7 +96,7 @@ module.exports = class InitWorkshop extends ActivityCommand {
                 reaction.users.remove(user.id);
 
                 if (emojiName === emojis[0]) {
-                    commandRegistry.findCommands('distribute-stamp', true)[0].runCommand(message, activity, { timeLimit: discordServices.stampCollectTime });
+                    commandRegistry.findCommands('distribute-stamp', true)[0].runCommand(message, activity, { timeLimit: botGuild.stamps.stampCollectionTime });
                 } else if (emojiName === emojis[1]) {
                     commandRegistry.findCommands('workshop-polls', true)[0].runCommand(message, activity, { questionType: 'speed' });
                 } else if (emojiName === emojis[2]) {
@@ -123,7 +121,7 @@ module.exports = class InitWorkshop extends ActivityCommand {
     // Hacker Side
         // message embed for helpChannel
         const helpEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle(activity.name + ' Help Desk')
             .setDescription('Welcome to the ' + activity.name + ' help desk. There are two ways to get help explained below:')
             .addField('Simple or Theoretical Questions', 'If you have simple or theory questions, use the !ask command on the text channel ' + '<#' + activity.generalText.id + '>' + '!')
@@ -164,7 +162,7 @@ module.exports = class InitWorkshop extends ActivityCommand {
                 var question = msgs.first().content;
 
                 const hackerEmbed = new Discord.MessageEmbed()
-                    .setColor(discordServices.colors.embedColor)
+                    .setColor(botGuild.colors.embedColor)
                     .setTitle('Hey there! We got you signed up to talk to a TA!')
                     .setDescription('You are number: ' + position + ' in the wait list.')
                     .addField(pullInFunctionality ? 'JOIN THE VOICE CHANNEL!' : 'KEEP AN EYE ON YOUR DMs', 

--- a/commands/a_activity/init-workshop.js
+++ b/commands/a_activity/init-workshop.js
@@ -3,6 +3,7 @@ const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const Activity = require('../../classes/activity');
 const ActivityCommand = require('../../classes/activity-command');
+const BotGuild = require('../../db/botGuildDBObject');
 
 // Command export
 module.exports = class InitWorkshop extends ActivityCommand {
@@ -18,10 +19,12 @@ module.exports = class InitWorkshop extends ActivityCommand {
 
     /**
      * Required class by children, should contain the command code.
-     * @param {Message} message - the message that has the command
+     * @param {Discord.Message} message - the message that has the command
      * @param {Activity} activity - the activity for this activity command
      */
     async activityCommand(message, activity) {
+
+        let botGuild = await BotGuild.findById(message.guild.id);
 
         let channels = await activity.makeWorkshop();
 
@@ -35,7 +38,7 @@ module.exports = class InitWorkshop extends ActivityCommand {
 
         ////// TA Side
         // embed color for mentors
-        var mentorColor = (await message.guild.roles.fetch(discordServices.roleIDs?.mentorRole))?.color || discordServices.randomColor();
+        var mentorColor = (await message.guild.roles.fetch(botGuild.roleIDs?.mentorRole))?.color || discordServices.randomColor();
 
         const taInfoEmbed = new Discord.MessageEmbed()
             .setTitle('TA Information')

--- a/commands/a_activity/new-activity.js
+++ b/commands/a_activity/new-activity.js
@@ -4,6 +4,8 @@ const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const Activity = require('../../classes/activity');
 const { numberPrompt } = require('../../classes/prompt');
+const { Document } = require('mongoose');
+
 
 // Command export
 module.exports = class NewActivity extends PermissionCommand {
@@ -30,7 +32,11 @@ module.exports = class NewActivity extends PermissionCommand {
         });
     }
 
-    async runCommand(message, {activityName}) {
+    /**
+     * @param {Document} botGuild
+     * @param {Discord.Message} message - the message in which the command was run
+     */
+    async runCommand(botGuild, message, {activityName}) {
 
         let activity = await new Activity(activityName, message.guild).init();
 
@@ -40,7 +46,7 @@ module.exports = class NewActivity extends PermissionCommand {
         // send message to console with emoji commands
         // message embed
         const msgEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('Activity: ' + activity.name + ' console.')
             .setDescription('This activity\'s information is below. For any changes you can use the emojis or direct commands.\n' + 
                 '🧑🏽‍💼 Will make this activity a workshop.\n' + 
@@ -52,7 +58,7 @@ module.exports = class NewActivity extends PermissionCommand {
                 '🔃 Will callback all users from all channels to the general channel.\n' + 
                 '👨‍👩‍👧‍👦 Will shuffle all the groups around the available channels.\n' + 
                 '🦜 Will shuffle all the mentors around the available channels.\n' +
-                '🏕️ Will activate a stamp distribution that will be open for ' + discordServices.stampCollectTime + ' seconds.\n' +
+                '🏕️ Will activate a stamp distribution that will be open for ' + botGuild.stamps.stampCollectionTime + ' seconds.\n' +
                 '🏎️ [FOR WORKSHOPS] Will send an embedded message asking how the speed is.\n' +
                 '✍️ [FOR WORKSHOPS] Will send an embedded message asking how the difficulty is.\n' +
                 '🧑‍🏫 [FOR WORKSHOPS] Will send an embedded message asking how good the explanations are.\n' + 
@@ -127,7 +133,7 @@ module.exports = class NewActivity extends PermissionCommand {
             } else if (emojiName === emojis[8]) {
                 commandRegistry.findCommands('shuffle-mentors', true)[0].runActivityCommand(message, activity);
             } else if (emojiName === emojis[9]) {
-                commandRegistry.findCommands('distribute-stamp', true)[0].runActivityCommand(message, activity, { timeLimit: discordServices.stampCollectTime });
+                commandRegistry.findCommands('distribute-stamp', true)[0].runActivityCommand(message, activity, { timeLimit: botGuild.stamps.stampCollectionTime });
             } else if (emojiName === emojis[10]) {
                 commandRegistry.findCommands('workshop-polls',true)[0].runActivityCommand(message, activity, { question: 'speed' });
             } else if (emojiName === emojis[11]) {

--- a/commands/a_activity/password-stamp.js
+++ b/commands/a_activity/password-stamp.js
@@ -2,6 +2,7 @@ const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const PermissionCommand = require('../../classes/permission-command');
 const Prompt = require('../../classes/prompt');
+const { Document } = require('mongoose');
 
 module.exports = class DistributeStamp extends PermissionCommand {
     constructor(client) {
@@ -39,14 +40,13 @@ module.exports = class DistributeStamp extends PermissionCommand {
     }
 
     /**
-     * 
+     * @param {Document} botGuild
      * @param {Discord.Message} message
      */
-    async runCommand(message, {activityName, password, stopTime}) {
+    async runCommand(botGuild, message, {activityName, password, stopTime}) {
         // helpful vars
         let channel = message.channel;
         let userId = message.author.id;
-
         // check if arguments have been given and prompt for the channel to use
         try {
             if (activityName === '') {
@@ -66,7 +66,7 @@ module.exports = class DistributeStamp extends PermissionCommand {
         }
 
         const qEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('React with anything to claim a stamp for attending ' + activityName)
             .setDescription('Once you react to this message, check for a DM from this bot. **You can only emoji this message once!**')
             .addField('A Password Is Required!', 'Through the Bot\'s DM, you will have 3 attempts in the first 60 seconds to enter the correct password.');
@@ -163,7 +163,7 @@ module.exports = class DistributeStamp extends PermissionCommand {
             
             if (stampNumber === 6) {
                 //manually set newRole to Stamp - 6 if stampNumber = 6 because otherwise it will end up being MEE6
-                newRole = message.guild.roles.cache.find(role => role.id === discordServices.stampRoles.stamp6Role);
+                newRole = message.guild.roles.cache.find(role => role.id === (await (BotGuild.findById(message.guild.id))).stampRoles.stamp6Role);
             }
             newRole = message.guild.roles.cache.find(role => 
                 !isNaN(role.name.substring(role.name.length - 2)) &&

--- a/commands/a_activity/password-stamp.js
+++ b/commands/a_activity/password-stamp.js
@@ -110,7 +110,7 @@ module.exports = class DistributeStamp extends PermissionCommand {
                 pwdCollector.on('collect', async m => {
                     //update role and stop collecting if password matches
                     if (m.content === password) {
-                        member.roles.cache.forEach(async role => (await this.parseRole(member, user, role, message, activityName)));
+                        member.roles.cache.forEach(async role => (await this.parseRole(member, user, role, message, activityName, botGuild)));
                         correctPassword = true;
                         //discordServices.deleteMessage(msgs);
                         discordServices.deleteMessage(dmMessage);
@@ -151,7 +151,7 @@ module.exports = class DistributeStamp extends PermissionCommand {
     }
 
     //replaces user's current role with the next one
-    async parseRole(member,user,curRole,message,activityName) {
+    async parseRole(member,user,curRole,message,activityName, botGuild) {
         var stampNumber; //keep track of which role should be next based on number of stamps
         var newRole; //next role based on stampNumber
         
@@ -163,7 +163,7 @@ module.exports = class DistributeStamp extends PermissionCommand {
             
             if (stampNumber === 6) {
                 //manually set newRole to Stamp - 6 if stampNumber = 6 because otherwise it will end up being MEE6
-                newRole = message.guild.roles.cache.find(role => role.id === (await (BotGuild.findById(message.guild.id))).stampRoles.stamp6Role);
+                newRole = message.guild.roles.cache.find(role => role.id === botGuild.stampRoles.stamp6Role);
             }
             newRole = message.guild.roles.cache.find(role => 
                 !isNaN(role.name.substring(role.name.length - 2)) &&

--- a/commands/a_activity/remove-activity.js
+++ b/commands/a_activity/remove-activity.js
@@ -19,7 +19,7 @@ module.exports = class RemoveActivity extends ActivityCommand {
      * @param {Message} message - the message that has the command
      * @param {Activity} activity - the activity for this activity command
      */
-    async activityCommand(message, activity) {
+    async activityCommand(botGuild, message, activity) {
         
         activity.delete();
 

--- a/commands/a_activity/remove-voice-channels.js
+++ b/commands/a_activity/remove-voice-channels.js
@@ -27,7 +27,7 @@ module.exports = class RemovePrivatesFor extends ActivityCommand {
      * @param {Message} message - the message that has the command
      * @param {Activity} activity - the activity for this activity command
      */
-    async activityCommand(message, activity, { number }) {
+    async activityCommand(botGuild, message, activity, { number }) {
         let final = activity.removeVoiceChannels(number);
 
         // report success of channel deletions

--- a/commands/a_activity/shuffle-groups.js
+++ b/commands/a_activity/shuffle-groups.js
@@ -20,7 +20,7 @@ module.exports = class GroupShuffle extends ActivityCommand {
      * @param {Message} message 
      * @param {Activity} activity 
      */
-    async activityCommand(message, activity) {
+    async activityCommand(botGuild, message, activity) {
 
         await ActivityManager.groupShuffle(activity);
 

--- a/commands/a_activity/shuffle-mentors.js
+++ b/commands/a_activity/shuffle-mentors.js
@@ -19,7 +19,7 @@ module.exports = class MentorShuffle extends ActivityCommand {
      * @param {Message} message 
      * @param {Activity} activity 
      */
-    async activityCommand(message, activity) {
+    async activityCommand(botGuild, message, activity) {
 
         ActivityManager.mentorShuffle(activity);
 

--- a/commands/a_activity/shuffle.js
+++ b/commands/a_activity/shuffle.js
@@ -20,7 +20,7 @@ module.exports = class ActivityShuffle extends ActivityCommand {
      * @param {Message} message 
      * @param {Activity} activity 
      */
-    async activityCommand(message, activity) {
+    async activityCommand(botGuild, message, activity) {
         
         ActivityManager.shuffle(activity);
 

--- a/commands/a_activity/workshop-polls.js
+++ b/commands/a_activity/workshop-polls.js
@@ -58,6 +58,6 @@ module.exports = class WorkshopPolls extends PermissionCommand {
             responses.set('🐇', 'Easy to understand?');
         }
 
-        ActivityManager.sendPoll(activity, title, question, responses);
+        ActivityManager.sendPoll(activity, title, question, responses, botGuild);
     }
 }

--- a/commands/a_activity/workshop-polls.js
+++ b/commands/a_activity/workshop-polls.js
@@ -32,7 +32,7 @@ module.exports = class WorkshopPolls extends PermissionCommand {
      * @param {Message} message - the message that has the command
      * @param {Activity} activity - the activity for this activity command
      */
-    async runCommand(message, activity, { questionType }) {
+    async runCommand(botGuild, message, activity, { questionType }) {
 
         let responses = new Discord.Collection();
         let title = '';

--- a/commands/a_boothing/add-private-boothing.js
+++ b/commands/a_boothing/add-private-boothing.js
@@ -20,13 +20,13 @@ module.exports = class CreatePrivates extends PermissionCommand {
             ],
         },
         {
-            roleID: discordServices.roleIDs.staffRole,
+            roleID: PermissionCommand.FLAGS.STAFF_ROLE,
             roleMessage: 'This command can only be ran by staff!',
         });
     }
 
 
-    async runCommand(message, {number}) {
+    async runCommand(botGuild, message, {number}) {
 
         // make sure command is only used in the boothing-wait-list channel
         if (message.channel.name != 'boothing-wait-list') {

--- a/commands/a_boothing/e-room-directory.js
+++ b/commands/a_boothing/e-room-directory.js
@@ -28,7 +28,7 @@ module.exports = class BoothDirectory extends PermissionCommand {
  * 
  * @param {Discord.Message} message - messaged that called this command
  */
-    async runCommand(message) {
+    async runCommand(botGuild, message) {
 
         // helpful vars
         let channel = message.channel;
@@ -51,8 +51,6 @@ module.exports = class BoothDirectory extends PermissionCommand {
         // prompt user for emoji to use
         let emoji = await Prompt.reactionPrompt({prompt: 'What emoji do you want to use?', channel, userId});
     
-        let botGuild = await BotGuild.findById(message.guild.id);
-
         //variable to keep track of state (Open vs Closed)
         var closed = true;
         //embed for closed state

--- a/commands/a_boothing/e-room-directory.js
+++ b/commands/a_boothing/e-room-directory.js
@@ -2,6 +2,7 @@ const PermissionCommand = require('../../classes/permission-command');
 const Discord = require('discord.js');
 const discordServices = require('../../discord-services');
 const Prompt = require('../../classes/prompt');
+const BotGuild = require('../../db/botGuildDBObject');
 
 module.exports = class BoothDirectory extends PermissionCommand {
     constructor(client) {
@@ -50,6 +51,8 @@ module.exports = class BoothDirectory extends PermissionCommand {
         // prompt user for emoji to use
         let emoji = await Prompt.reactionPrompt({prompt: 'What emoji do you want to use?', channel, userId});
     
+        let botGuild = await BotGuild.findById(message.guild.id);
+
         //variable to keep track of state (Open vs Closed)
         var closed = true;
         //embed for closed state
@@ -64,8 +67,8 @@ module.exports = class BoothDirectory extends PermissionCommand {
             msg.react(emoji);
             //only listen for the door react from Staff and Sponsors
             const emojiFilter = (reaction, user) => (reaction.emoji.name === emoji.name) && 
-                (discordServices.checkForRole(message.guild.member(user), discordServices.roleIDs.staffRole) || 
-                    discordServices.checkForRole(message.guild.member(user), discordServices.roleIDs?.sponsorRole));
+                (discordServices.checkForRole(message.guild.member(user), botGuild.roleIDs.staffRole) || 
+                    discordServices.checkForRole(message.guild.member(user), botGuild.roleIDs?.sponsorRole));
             const emojiCollector = msg.createReactionCollector(emojiFilter);
             
             var announcementMsg;

--- a/commands/a_boothing/e-room-directory.js
+++ b/commands/a_boothing/e-room-directory.js
@@ -65,8 +65,7 @@ module.exports = class BoothDirectory extends PermissionCommand {
             msg.react(emoji);
             //only listen for the door react from Staff and Sponsors
             const emojiFilter = (reaction, user) => (reaction.emoji.name === emoji.name) && 
-                (discordServices.checkForRole(message.guild.member(user), botGuild.roleIDs.staffRole) || 
-                    discordServices.checkForRole(message.guild.member(user), botGuild.roleIDs?.sponsorRole));
+                discordServices.checkForRole(message.guild.member(user), botGuild.roleIDs.staffRole);
             const emojiCollector = msg.createReactionCollector(emojiFilter);
             
             var announcementMsg;

--- a/commands/a_boothing/remove-private-boothing.js
+++ b/commands/a_boothing/remove-private-boothing.js
@@ -20,13 +20,13 @@ module.exports = class RemovePrivates extends PermissionCommand {
             ],
         },
         {
-            roleID: discordServices.roleIDs.staffRole,
+            roleID: PermissionCommand.FLAGS.STAFF_ROLE,
             roleMessage: 'This command can only be ran by staff!',
         });
     }
 
 
-    async runCommand(message, {number}) {
+    async runCommand(botGuild, message, {number}) {
 
         // make sure command is only used in the boothing-wait-list channel
         if (message.channel.name != 'boothing-wait-list') {

--- a/commands/a_boothing/start-boothing.js
+++ b/commands/a_boothing/start-boothing.js
@@ -4,6 +4,8 @@ const firebaseServices = require('../../firebase-services/firebase-services');
 const firebaseBoothing = require('../../firebase-services/firebase-services-boothing')
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
+const { Document } = require('mongoose');
+
 
 // Command export
 module.exports = class StartBoothing extends PermissionCommand {
@@ -17,13 +19,17 @@ module.exports = class StartBoothing extends PermissionCommand {
             args: [],
         },
         {
-            roleID: discordServices.roleIDs.adminRole,
+            roleID: PermissionCommand.FLAGS.ADMIN_ROLE,
             roleMessage: 'This command can only be ran by admins!'
         });
     }
 
-
-    async runCommand(message) {
+    /**
+     * 
+     * @param {Document} botGuild 
+     * @param {Discord.Message} message 
+     */
+    async runCommand(botGuild, message) {
 
         // make sure command is only used in the boothing-wait-list channel
         if (message.channel.name != 'boothing-wait-list') {
@@ -34,7 +40,7 @@ module.exports = class StartBoothing extends PermissionCommand {
         ////// hacker side message
         // message to send describing the different emojis
         const textEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('Sponsor Boothing')
             .setDescription('Welcome to our sponsor booth! Please react to one of the emojis below to get started!')
             .addField('Join Wait List Alone', 'If you want to join the wait list by yourself please react to ' + ':sunglasses:')
@@ -49,7 +55,7 @@ module.exports = class StartBoothing extends PermissionCommand {
         var sponsorChannel = await message.guild.channels.resolve(discordServices.sponsorConsoleChannel);
 
         const sponsorEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('The Wait List')
             .setDescription('This is the wait list, it will always stay up to date! To get the next group react to this message with 🤝');
 
@@ -126,7 +132,7 @@ module.exports = class StartBoothing extends PermissionCommand {
 
         // message to be sent to hacker
         const dmEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('Sponsor Boothing Wait List')
             .setDescription('Hey there! We got you signed up to talk to a sponsor! Sit tight in the voice channel. If you ' +
                 'are not in the voice channel when its your turn you will be skipped, and we do not want that to happen!')

--- a/commands/a_start_commands/start-channel-creation.js
+++ b/commands/a_start_commands/start-channel-creation.js
@@ -24,10 +24,10 @@ module.exports = class StartChannelCreation extends PermissionCommand {
     }
 
     /**
-     *  
-     * @param {Discord.Message} message 
+     * @param {Document} botGuild
+     * @param {Discord.Message} message - the message in which the command was run
      */
-    async runCommand(message) {
+    async runCommand(botGuild, message) {
 
         try {
             // grab current channel
@@ -36,8 +36,6 @@ module.exports = class StartChannelCreation extends PermissionCommand {
             message.channel.send('<@' + message.author.id + '> The command has been canceled due to the prompt cancel.').then(msg => msg.delete({timeout: 5000}));
             return;
         }
-
-        let botGuild = await BotGuild.findById(message.guild.id);
 
         // grab channel creation category and update permissions
         var category = channel.parent;
@@ -52,7 +50,7 @@ module.exports = class StartChannelCreation extends PermissionCommand {
         
         // create and send embed message to channel with emoji collector
         const msgEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('Private Channel Creation')
             .setDescription('Do you need a private channel to work with your friends? Or a voice channel to get to know a mentor, here you can create private text or voice channels.' +
                 ' However do know that server admins will have access to these channels, and the bot will continue to monitor for bad language, so please follow the rules!')

--- a/commands/a_start_commands/start-channel-creation.js
+++ b/commands/a_start_commands/start-channel-creation.js
@@ -3,6 +3,7 @@ const PermissionCommand = require('../../classes/permission-command');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const Prompt = require('../../classes/prompt');
+const BotGuild = require('../../db/botGuildDBObject');
 
 // Command export
 module.exports = class StartChannelCreation extends PermissionCommand {
@@ -36,13 +37,15 @@ module.exports = class StartChannelCreation extends PermissionCommand {
             return;
         }
 
+        let botGuild = await BotGuild.findById(message.guild.id);
+
         // grab channel creation category and update permissions
         var category = channel.parent;
-        category.updateOverwrite(discordServices.roleIDs.everyoneRole, {
+        category.updateOverwrite(botGuild.roleIDs.everyoneRole, {
             VIEW_CHANNEL: false,
         });
 
-        channel.updateOverwrite(discordServices.roleIDs.everyoneRole, {
+        channel.updateOverwrite(botGuild.roleIDs.everyoneRole, {
             VIEW_CHANNEL: true,
         });
 

--- a/commands/a_start_commands/start-mentor-cave.js
+++ b/commands/a_start_commands/start-mentor-cave.js
@@ -24,10 +24,10 @@ module.exports = class StartMentors extends PermissionCommand {
     }
 
     /**
-     * 
-     * @param {Discord.Message} message - a message
+     * @param {Document} botGuild
+     * @param {Discord.Message} message - the message in which the command was run
      */
-    async runCommand(message) {
+    async runCommand(botGuild, message) {
         try {
             // helpful prompt vars
             let channel = message.channel;
@@ -93,7 +93,7 @@ module.exports = class StartMentors extends PermissionCommand {
             });
 
 
-            let adminConsole = message.guild.channels.resolve(discordServices.channelIDs.adminConsoleChannel);
+            let adminConsole = message.guild.channels.resolve(botGuild.channelIDs.adminConsole);
 
             try {
                 let isCreated = await Prompt.yesNoPrompt({prompt: 'Are the categories and channels already created?', channel, userId});

--- a/commands/a_start_commands/start-team-formation.js
+++ b/commands/a_start_commands/start-team-formation.js
@@ -27,7 +27,7 @@ module.exports = class StartTeamFormation extends PermissionCommand {
      * 
      * @param {Discord.Message} message - the message in which the command was run
      */
-    async runCommand(message) {
+    async runCommand(botGuild, message) {
         // helpful prompt vars
         let channel = message.channel;
         let userId = message.author.id;

--- a/commands/a_start_commands/start-team-roulette.js
+++ b/commands/a_start_commands/start-team-roulette.js
@@ -4,6 +4,8 @@ const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const Prompt = require('../../classes/prompt.js');
 const Team = require('../../classes/team');
+const BotGuild = require('../../db/botGuildDBObject');
+const {Document} = require('mongoose');
 
 // Command export
 module.exports = class StartTeamRoulette extends PermissionCommand {
@@ -28,10 +30,12 @@ module.exports = class StartTeamRoulette extends PermissionCommand {
     }
 
     /**
-     * 
+     * @param {Document} botGuild
      * @param {Discord.Message} message - the message in which the command was run
      */
-    async runCommand(message) {
+    async runCommand(botGuild, message) {
+
+        this.botGuild = botGuild;
 
         /**
          * The solo join emoji.
@@ -81,7 +85,7 @@ module.exports = class StartTeamRoulette extends PermissionCommand {
                 
         // create and send embed message to channel with emoji collector
         const msgEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(this.botGuild.colors.embedColor)
             .setTitle('Team Roulette Information')
             .setDescription('Welcome to the team roulette section! If you are looking to join a random team, you are in the right place!')
             .addField('How does this work?', 'Reacting to this message will get you or your team on a list. I will try to assign you a team of 4 as fast as possible. When I do I will notify you on a private text channel with your new team!')
@@ -269,7 +273,7 @@ module.exports = class StartTeamRoulette extends PermissionCommand {
         // let user know everything is good to go
         let listEmoji = '📰';
 
-        const adminEmbed = new Discord.MessageEmbed().setColor(discordServices.colors.embedColor)
+        const adminEmbed = new Discord.MessageEmbed().setColor(this.botGuild.colors.embedColor)
                                     .setTitle('Team Roulette Console')
                                     .setDescription('Team roulette is ready and operational! <#' + channel.id + '>.')
                                     .addField('Check the list!', 'React with ' + listEmoji + ' to get a message with the roulette team lists.');
@@ -282,7 +286,7 @@ module.exports = class StartTeamRoulette extends PermissionCommand {
         adminEmbedMsgCollector.on('collect', (reaction, user) => {
             reaction.users.remove(user.id);
 
-            let infoEmbed = new Discord.MessageEmbed().setColor(discordServices.colors.embedColor)
+            let infoEmbed = new Discord.MessageEmbed().setColor(this.botGuild.colors.embedColor)
                                         .setTitle('Team Roulette Information')
                                         .setDescription('These are all the teams that are still waiting.');
 
@@ -301,7 +305,8 @@ module.exports = class StartTeamRoulette extends PermissionCommand {
         });
 
         // add channel to black list
-        discordServices.blackList.set(channel.id, 5000);
+        this.botGuild.blackList.set(channel.id, 5000);
+        this.botGuild.save();
         return channel;
     }
 
@@ -355,7 +360,7 @@ module.exports = class StartTeamRoulette extends PermissionCommand {
             let leaveEmoji = '👋';
 
             const infoEmbed = new Discord.MessageEmbed()
-                .setColor(discordServices.colors.embedColor)
+                .setColor(this.botGuild.colors.embedColor)
                 .setTitle('WELCOME TO YOUR NEW TEAM!!!')
                 .setDescription('This is your new team, please get to know each other by creating a voice channel in a new Discord server or via this text channel. Best of luck!')
                 .addField('Leave the Team', 'If you would like to leave this team react to this message with ' + leaveEmoji);

--- a/commands/a_utility/change-stamp-time.js
+++ b/commands/a_utility/change-stamp-time.js
@@ -1,5 +1,7 @@
 const PermissionCommand = require('../../classes/permission-command');
 const discordServices = require('../../discord-services');
+const { Message } = require('discord.js');
+const { Document } = require('mongoose');
 
 // Command export
 module.exports = class ChangeStampTime extends PermissionCommand {
@@ -24,9 +26,16 @@ module.exports = class ChangeStampTime extends PermissionCommand {
         });
     }
 
-    async runCommand(message, {newTime}) {
+    /**
+     * 
+     * @param {Document} botGuild 
+     * @param {Message} message 
+     * @param {*} param2 
+     */
+    async runCommand(botGuild, message, {newTime}) {
 
-        discordServices.stampCollectTime = newTime;
+        botGuild.stamps.stampCollectionTime = newTime;
+        botGuild.save()
 
         discordServices.replyAndDelete(message, 'Stamp collection will now give hackers ' + newTime + ' seconds to collect stamp.');
     }

--- a/commands/a_utility/clear-chat.js
+++ b/commands/a_utility/clear-chat.js
@@ -2,6 +2,7 @@
 const PermissionCommand = require('../../classes/permission-command');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
+const BotGuild = require('../../db/botGuildDBObject');
 
 // Command export
 module.exports = class ClearChat extends PermissionCommand {
@@ -33,8 +34,11 @@ module.exports = class ClearChat extends PermissionCommand {
         });
     }
 
-
-  async runCommand (message, {keepPinned, isCommands}) {
+    /**
+     * @param {Document} botGuild
+     * @param {Discord.Message} message - the message in which the command was run
+     */
+    async runCommand (botGuild, message, {keepPinned, isCommands}) {
 
         if (keepPinned) {
             // other option is to get all channel messages, filter of the pined channels and pass those to bulkDelete, might be to costly?
@@ -52,11 +56,11 @@ module.exports = class ClearChat extends PermissionCommand {
         // only proceed if we want the commands
         if (isCommands) {
             // if in the verify channel <welcome>
-            if (message.channel.id === discordServices.channelIDs.welcomeChannel) {
+            if (message.channel.id === botGuild.verification?.welcomeChannelID) {
                 commands = this.client.registry.findCommands('verify');
             } 
             // admin console
-            else if (discordServices.isAdminConsole(message.channel)) {
+            else if (( await discordServices.isAdminConsole(message.channel))) {
                 // grab all the admin command groups
                 var commandGroups = this.client.registry.findGroups('a_');
                 // add all the commands from the command groups
@@ -74,7 +78,7 @@ module.exports = class ClearChat extends PermissionCommand {
             var length = commands.length;
 
             const textEmbed = new Discord.MessageEmbed()
-                .setColor(discordServices.colors.embedColor)
+                .setColor(botGuild.colors.embedColor)
                 .setTitle('Commands Available in this Channel')
                 .setDescription('The following are all the available commands in this channel, for more information about a specific command please call !help <command_name>.')
                 .setTimestamp();

--- a/commands/a_utility/clear-chat.js
+++ b/commands/a_utility/clear-chat.js
@@ -60,7 +60,7 @@ module.exports = class ClearChat extends PermissionCommand {
                 commands = this.client.registry.findCommands('verify');
             } 
             // admin console
-            else if (( await discordServices.isAdminConsole(message.channel))) {
+            else if (message.channel.id === botGuild.channelIDs.adminConsole) {
                 // grab all the admin command groups
                 var commandGroups = this.client.registry.findGroups('a_');
                 // add all the commands from the command groups

--- a/commands/a_utility/raffle.js
+++ b/commands/a_utility/raffle.js
@@ -41,8 +41,7 @@ module.exports = class Raffle extends PermissionCommand {
      * @param {Discord.Message} message - message used to call the command
      * @param {integer} numberOfWinners - number of winners to be drawn
      */
-    async runCommand(message, {numberOfWinners}) {
-        let botGuild = await BotGuild.findById(message.guild.id);
+    async runCommand(botGuild, message, {numberOfWinners}) {
 
         //check that numberOfWinners is less than the number of people with stamp roles or it will infinite loop
         var memberCount = message.guild.members.cache.filter(member => member.roles.cache.has(botGuild.roleIDs.memberRole)).size;
@@ -73,7 +72,7 @@ module.exports = class Raffle extends PermissionCommand {
         }
         winners = Array.from(winners);
         const embed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('The winners of the raffle draw are:')
             .setDescription('<@' + winners.join('><@') + '>');
         await message.channel.send(embed);

--- a/commands/a_utility/raffle.js
+++ b/commands/a_utility/raffle.js
@@ -1,6 +1,7 @@
 const PermissionCommand = require('../../classes/permission-command');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
+const BotGuild = require('../../db/botGuildDBObject');
 
 /**
  * The Raffle class randomly picks a set number of winners from all members in a Discord server that have a role ending in a 1-2 digit 
@@ -37,12 +38,14 @@ module.exports = class Raffle extends PermissionCommand {
      * into an array. Then it chooses random numbers and picks the id corresponding to that index until it has numberOfWinners unique 
      * winners.
      * 
-     * @param {message} message - message used to call the command
+     * @param {Discord.Message} message - message used to call the command
      * @param {integer} numberOfWinners - number of winners to be drawn
      */
     async runCommand(message, {numberOfWinners}) {
+        let botGuild = await BotGuild.findById(message.guild.id);
+
         //check that numberOfWinners is less than the number of people with stamp roles or it will infinite loop
-        var memberCount = message.guild.members.cache.filter(member => member.roles.cache.has(discordServices.roleIDs.memberRole)).size;
+        var memberCount = message.guild.members.cache.filter(member => member.roles.cache.has(botGuild.roleIDs.memberRole)).size;
         if (memberCount <= numberOfWinners) {
             message.channel.send("Whoa there, you have more winners than hackers!").then((msg) => {
                 msg.delete({ timeout: 5000 })

--- a/commands/a_utility/role-selector.js
+++ b/commands/a_utility/role-selector.js
@@ -3,7 +3,7 @@ const PermissionCommand = require('../../classes/permission-command');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const Prompt = require('../../classes/prompt');
-const BotGuild = require('../../db/botGuildDBObject');
+const { Document } = require('mongoose');
 
 // Command export
 module.exports = class RoleSelector extends PermissionCommand {
@@ -23,12 +23,10 @@ module.exports = class RoleSelector extends PermissionCommand {
 
 
     /**
-     * 
+     * @param {Document} botGuild
      * @param {Discord.Message} message - the command message
      */
-    async runCommand (message) {
-
-        let botGuild = await BotGuild.findById(message.guild.id);
+    async runCommand (botGuild, message) {
 
         // the emoji for staff to add new transfers
         let newTransferEmoji = '🆕';
@@ -46,7 +44,7 @@ module.exports = class RoleSelector extends PermissionCommand {
          */
         let transfers = new Discord.Collection();
 
-        const cardEmbed = new Discord.MessageEmbed().setColor(discordServices.colors.embedColor)
+        const cardEmbed = new Discord.MessageEmbed().setColor(botGuild.colors.embedColor)
             .setTitle('Role Selector!')
             .setDescription('React to the specified emoji to get the role, un-react to remove the role.');
 

--- a/commands/a_utility/role-selector.js
+++ b/commands/a_utility/role-selector.js
@@ -3,6 +3,7 @@ const PermissionCommand = require('../../classes/permission-command');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const Prompt = require('../../classes/prompt');
+const BotGuild = require('../../db/botGuildDBObject');
 
 // Command export
 module.exports = class RoleSelector extends PermissionCommand {
@@ -26,6 +27,8 @@ module.exports = class RoleSelector extends PermissionCommand {
      * @param {Discord.Message} message - the command message
      */
     async runCommand (message) {
+
+        let botGuild = await BotGuild.findById(message.guild.id);
 
         // the emoji for staff to add new transfers
         let newTransferEmoji = '🆕';
@@ -56,7 +59,7 @@ module.exports = class RoleSelector extends PermissionCommand {
         // add role or a transfer depending on the emoji
         reactionCollector.on('collect', async (reaction, user) => {
             // admin add new transfer
-            if (reaction.emoji.name === newTransferEmoji && discordServices.checkForRole(message.guild.member(user), discordServices.roleIDs.staffRole)) {
+            if (reaction.emoji.name === newTransferEmoji && discordServices.checkForRole(message.guild.member(user), botGuild.roleIDs.staffRole)) {
                 
                 try {
                     var newTransferMsg = await Prompt.messagePrompt({prompt: 'What new transfer do you want to add? Your response should have (in this order, not including <>): @role <transfer name> - <transfer description>',

--- a/commands/essentials/help.js
+++ b/commands/essentials/help.js
@@ -2,6 +2,7 @@
 const { Command } = require('discord.js-commando');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
+const BotGuild = require('../../db/botGuildDBObject');
 
 // Command export
 module.exports = class ClearChat extends Command {
@@ -16,6 +17,8 @@ module.exports = class ClearChat extends Command {
     }
 
     async run(message) {
+
+        let botGuild = await BotGuild.findById(message.guild.id);
         
         var commands = [];
 
@@ -25,7 +28,7 @@ module.exports = class ClearChat extends Command {
         } else {
             discordServices.deleteMessage(message);
 
-            if ((discordServices.checkForRole(message.member, discordServices.roleIDs.staffRole))) {
+            if ((discordServices.checkForRole(message.member, botGuild.roleIDs.staffRole))) {
                 var commandGroups = this.client.registry.findGroups('a_');
             } else {
                 var commandGroups = this.client.registry.findGroups('utility');

--- a/commands/essentials/help.js
+++ b/commands/essentials/help.js
@@ -45,7 +45,7 @@ module.exports = class ClearChat extends Command {
         var length = commands.length;
 
         const textEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('Commands Available for you')
             .setDescription('All other interactions with me will be via emoji reactions!')
             .setTimestamp();

--- a/commands/essentials/init-bot.js
+++ b/commands/essentials/init-bot.js
@@ -107,6 +107,7 @@ module.exports = class InitBot extends Command {
 
         // grab the admin role
         const adminRole = await this.askOrCreate('admin', channel, userId, guild, '#008369');
+        discordServices.addRoleToMember(message.author, adminRole);
 
         // create the admin channel package
         let {adminConsole, adminLog} = await BotGuild.createAdminChannels(guild, adminRole, everyoneRole);

--- a/commands/essentials/init-bot.js
+++ b/commands/essentials/init-bot.js
@@ -50,6 +50,11 @@ module.exports = class InitBot extends Command {
             message.reply('Only admins can use this command!').then(msg => msg.delete({timeout: 5000}));
         }
 
+        if (botGuild?.isSetUpComplete) {
+            discordServices.sendMsgToChannel(channel, userId, 'This guild is already set up!!', 30);
+            return;
+        }
+
         if (isDev) {
             const file = './dev_config.json';
             let data = await jsonfile.readFile(file);
@@ -82,6 +87,8 @@ module.exports = class InitBot extends Command {
             if (data.isStampOn) {
                 await botGuild.setUpStamps(this.client, undefined, undefined, data.stamps);
             }
+
+            botGuild.isSetUpComplete = true;
 
             await botGuild.save();
 

--- a/commands/essentials/init-bot.js
+++ b/commands/essentials/init-bot.js
@@ -4,6 +4,7 @@ const Discord = require('discord.js');
 const discordServices = require('../../discord-services');
 const Prompt = require('../../classes/prompt');
 const jsonfile = require('jsonfile');
+const BotGuild = require('../../classes/bot-guild');
 
 // Command export
 module.exports = class InitBot extends Command {
@@ -32,6 +33,8 @@ module.exports = class InitBot extends Command {
     async run(message, { isDev }) {
         message.delete();
 
+        const botGuild = new BotGuild(message.guild.id);
+
         // make sure the user had manage server permission
         if (!message.member.hasPermission('MANAGE_GUILD')) {
             message.reply('Only admins can use this command!').then(msg => msg.delete({timeout: 5000}));
@@ -41,39 +44,41 @@ module.exports = class InitBot extends Command {
             const file = './dev_config.json';
             let data = await jsonfile.readFile(file);
             
-            discordServices.roleIDs.adminRole = data.adminRoleID;
-            discordServices.roleIDs.staffRole = data.staffRoleID;
-            discordServices.roleIDs.memberRole = data.memberRoleID;
-            discordServices.roleIDs.everyoneRole = data.everyoneRoleID;
-            
-            discordServices.channelIDs.adminConsoleChannel = data.adminConsoleID;
-            discordServices.channelIDs.adminLogChannel = data.adminLogsID;
+            botGuild.readyUp(this.client, {
+                roleIDs:{
+                    adminRole: data.adminRoleID,
+                    staffRole: data.staffRoleID,
+                    memberRole: data.memberRoleID,
+                    everyoneRole: data.everyoneRoleID,
+                },
+                channelIDs: {
+                    adminConsole: data.adminConsoleID,
+                    adminLog: data.adminLogsID,
+                    botSupportChannel: data.botSupportChannelID
+                }
+            })
 
             if (data.isVerificationOn) {
-                discordServices.roleIDs.guestRole = data.guestRoleID;
-                discordServices.channelIDs.welcomeChannel = data.welcomeChannelID;
-                discordServices.channelIDs.welcomeSupport = data.welcomeChannelSupportID;
+                botGuild.setUpVerification(this.client, data.guestRoleID, {
+                    welcomeChannelID: data.welcomeChannelID,
+                    welcomeChannelSupportID: data.welcomeChannelSupportID,
+                });
             }
 
             if (data.isAttendanceOn) {
-                discordServices.roleIDs.attendeeRole = data.attendeeRoleID;
+                botGuild.setUpAttendance(this.client, data.attendeeRoleID);
             }
-
-            discordServices.channelIDs.botSupportChannel = data.botSupportChannelID;
-
-            discordServices.roleIDs.mentorRole = data.mentorRoleID;
-            discordServices.roleIDs.sponsorRole = data.sponsorRoleID;
 
             if (data.isStampOn) {
-                data.stamps.forEach((ID, index, array) => {
-                    discordServices.stampRoles.set(index, ID);
-                });
+                botGuild.setUpStamps(this.client, undefined, undefined, data.stamps);
             }
+
+            discordServices.sendMsgToChannel(channel, userId, 'The bot is set and ready to hack!', 10);
 
             return;
         }
 
-        const embedInfo = new Discord.MessageEmbed().setColor(discordServices.colors.embedColor)
+        const embedInfo = new Discord.MessageEmbed().setColor(botGuild.colors.embedColor)
             .setTitle('Hackabot Console')
             .setTimestamp()
             .setDescription('Bot information will be added here! You can make changes here as well!')
@@ -92,19 +97,8 @@ module.exports = class InitBot extends Command {
         const adminRole = await this.askOrCreate('admin', channel, userId, guild, '#008369');
 
         // create the admin channel package
-        let adminConsole = await this.createAdminChannels(guild, adminRole, everyoneRole);
-        await discordServices.sendMsgToChannel(channel, userId, 'The admin channels have been created successfully! <#' + discordServices.channelIDs.adminConsoleChannel + '>. Lets jump over there and continue yes?!', 60);
-        
-        // try giving the admins administrator perms
-        try {
-            if (!adminRole.permissions.has('ADMINISTRATOR')) 
-            {
-                adminRole.setPermissions(adminRole.permissions.add(['ADMINISTRATOR']));
-                await adminRole.setMentionable(true);
-            }
-        } catch {
-            discordServices.discordLog(guild, 'Was not able to give administrator privileges to the role <@&' + adminRole.id + '>. Please help me!')
-        }
+        let {adminConsole, adminLog} = await BotGuild.createAdminChannels(guild, adminRole, everyoneRole);
+        await discordServices.sendMsgToChannel(channel, userId, 'The admin channels have been created successfully! <#' + adminConsole.id + '>. Lets jump over there and continue yes?!', 60);
 
         // transition to the admin console
         var channel = adminConsole;
@@ -113,32 +107,40 @@ module.exports = class InitBot extends Command {
 
         // grab the staff role
         const staffRole = await this.askOrCreate('staff', channel, userId, guild, '#00D166');
-        staffRole.setMentionable(true);
-        staffRole.setHoist(true);
-        staffRole.setPermissions(staffRole.permissions.add(['VIEW_CHANNEL', 'MANAGE_EMOJIS', 'CHANGE_NICKNAME', 'MANAGE_NICKNAMES', 
-            'KICK_MEMBERS', 'BAN_MEMBERS', 'SEND_MESSAGES', 'EMBED_LINKS', 'ATTACH_FILES', 'ADD_REACTIONS', 'USE_EXTERNAL_EMOJIS', 'MANAGE_MESSAGES', 
-            'READ_MESSAGE_HISTORY', 'CONNECT', 'STREAM', 'SPEAK', 'PRIORITY_SPEAKER', 'USE_VAD', 'MUTE_MEMBERS', 'DEAFEN_MEMBERS', 'MOVE_MEMBERS']));
 
         // get the regular member, this role will have the general member permissions
         const memberRole = await this.askOrCreate('member', channel, userId, guild, '#006798');
-        memberRole.setMentionable(false);
-        memberRole.setPermissions(memberRole.permissions.add(['VIEW_CHANNEL', 'CHANGE_NICKNAME', 'SEND_MESSAGES', 'ADD_REACTIONS', 'READ_MESSAGE_HISTORY',
-        'CONNECT', 'SPEAK', 'STREAM', 'USE_VAD']));
 
-        // change the everyone role permissions
-        everyoneRole.setPermissions(0); // no permissions for anything like the guest role
+        // bot support channel prompt
+        let botSupportChannel = await this.askForBotSupportChannel(channel, userId);
 
-        // set discordServices roles
-        discordServices.roleIDs.memberRole = memberRole.id;
-        discordServices.roleIDs.staffRole = staffRole.id;
-        discordServices.roleIDs.adminRole = adminRole.id;
-        discordServices.roleIDs.everyoneRole = everyoneRole.id;
-
+        botGuild.readyUp(this.client, {
+            roleIDs: {
+                adminRole: adminRole.id,
+                staffRole: staffRole.id,
+                everyoneRole: everyoneRole.id,
+                memberRole: memberRole.id,
+            },
+            channelIDs: {
+                adminLog: adminLog.id,
+                adminConsole: adminConsole.id,
+                botSupportChannel: botSupportChannel.id,
+            }
+        });
         
         // ask if verification will be used
         try {
             if (await Prompt.yesNoPrompt({prompt: 'Will you be using the verification service?', channel, userId})) {
-                await this.setVerification(channel, userId, guild, everyoneRole, memberRole);
+                // ask for guest role
+                var guestRole;
+                try {
+                    guestRole = await this.askOrCreate('guest', channel, userId, guild, '#969C9F');
+                } catch (error) {
+                    discordServices.sendMsgToChannel(channel, userId, 'You need to give a guest role! Please try again', 10);
+                    return this.setVerification(channel, userId, guild, everyoneRole);
+                }
+
+                await botGuild.setUpVerification(this.client, guestRole.id);
                 discordServices.sendMsgToChannel(channel, userId, 'The verification service has been set up correctly!', 60);
             }
         } catch (error) {
@@ -148,11 +150,9 @@ module.exports = class InitBot extends Command {
 
         // ask if attendance will be used
         try {
-            if (await Prompt.yesNoPrompt({prompt: 'Will you be using the attendance service?', channel, userId})) {
-                guild.setCommandEnabled('start-attend', true);
-    
+            if (await Prompt.yesNoPrompt({prompt: 'Will you be using the attendance service?', channel, userId})) {    
                 const attendeeRole = await this.askOrCreate('attendee', channel, userId, guild, '#0099E1');
-                discordServices.roleIDs.attendeeRole = attendeeRole.id;
+                await botGuild.setUpAttendance(this.client, attendeeRole.id);
                 discordServices.sendMsgToChannel(channel, userId, 'The attendance service has been set up correctly!', 60);
             } else {
                 discordServices.sendMsgToChannel(channel, userId, 'Attendance was not set up!', 60);
@@ -165,7 +165,8 @@ module.exports = class InitBot extends Command {
         // ask if the announcements will be used
         try {
             if (await Prompt.yesNoPrompt({prompt: 'Have firebase announcements been set up code-side? If not say no, or the bot will fail!', channel, userId})) {
-                await this.setAnnouncements(channel, userId);
+                let announcementChannel = (await Prompt.channelPrompt('What channel should announcements be sent to? If you don\'t have it, create it and come back, do not cancel.')).first();
+                botGuild.setUpAnnouncements(this.client, announcementChannel.id);
                 discordServices.sendMsgToChannel(channel, userId, 'The announcements have been set up correctly!', 60);
             } else {
                 discordServices.sendMsgToChannel(channel, userId, 'Announcements functionality was not set up.', 10);
@@ -178,19 +179,9 @@ module.exports = class InitBot extends Command {
         // ask if the stamps will be used
         try {
             if (await Prompt.yesNoPrompt({prompt: 'Will you be using the stamp service?', channel, userId})) {
-                let numberOfStamps = (await Prompt.numberPrompt({prompt: 'How many stamps do you want? This number is final!', channel, userId}))[0];
+                let numberOfStamps = await Prompt.numberPrompt({prompt: 'How many stamps do you want?', channel, userId})[0];
 
-                for (let i = 0; i < numberOfStamps; i++) {
-                    let role = await guild.roles.create({
-                        data: {
-                            name: 'Stamp Role #' + i,
-                            hoist: true,
-                            color: Math.floor(Math.random()*16777215).toString(16),
-                        }
-                    });
-                    discordServices.stampRoles.set(i, role.id);
-                }
-
+                await botGuild.setUpStamps(this.client, numberOfStamps);
                 discordServices.sendMsgToChannel(channel, userId, 'The stamp roles have been created, you can change their name and/or color, but their stamp number is final!', 60);
             } else {
                 discordServices.sendMsgToChannel(channel, userId, 'The stamp functionality was not set up.', 10);
@@ -200,17 +191,12 @@ module.exports = class InitBot extends Command {
         }
 
 
-        // bot support channel prompt
-        await this.askForBotSupportChannel(channel, userId);
-
-
         // ask if the user will use the report functionality
         try {
             if (await Prompt.yesNoPrompt({prompt: 'Will you be using the report functionality?', channel, userId})) {
                 let incomingReportChannel = (await Prompt.channelPrompt({prompt: 'What channel should prompts be sent to? We recommend this channel be accessible to your staff.', channel, userId})).first();
-                discordServices.channelIDs.incomingReportChannel = incomingReportChannel.id;
-
-                guild.setCommandEnabled('report', true);
+                
+                botGuild.setUpReport(this.client, incomingReportChannel.id);
                 discordServices.sendMsgToChannel(channel, userId, 'The report command is available and reports will be sent to: <#' + incomingReportChannel.id + '>', 60);
             }
         } catch (error) {
@@ -221,177 +207,29 @@ module.exports = class InitBot extends Command {
         // ask if the user wants to use the experimental !ask command
         try {
             if (await Prompt.yesNoPrompt({prompt: 'Do you want to let users use the experimental !ask command?', channel, userId})) {
-                guild.setCommandEnabled('ask', true);
+                botGuild.setUpAsk(this.client);
                 discordServices.sendMsgToChannel(channel, userId, 'The ask command is now available to the server users.', 60);
             }
         } catch (error) {
             discordServices.sendMsgToChannel(channel, userId, 'Ask command will not be loaded due to prompt cancel.', 10);
         }
 
-
-        this.client.registry.groups.forEach((group, key, map) => {
-            if (group.name.startsWith('a_')) guild.setGroupEnabled(group, true);
-        });
-
         discordServices.sendMsgToChannel(channel, userId, 'The bot is set and ready to hack!', 10);
-
-        // TODO remove this when fixed
-        try {
-            discordServices.roleIDs.mentorRole = (await Prompt.rolePrompt({prompt: 'What is the mentor role', channel, userId})).first();
-            discordServices.roleIDs.sponsorRole = (await Prompt.rolePrompt({prompt: 'What is the sponsor role?', channel, userId})).first();
-        } catch (error) {
-            discordServices.sendMsgToChannel(channel, userId, 'Mentor and/or Sponsor verification was not set due to cancel prompt!');
-        }
     }
 
     /**
      * Will ask the user for a channel to be used for the bot, cancellations are not allowed.
      * @param {Discord.TextChannel} channel 
      * @param {Discord.Snowflake} userId 
+     * @returns {Promise<Discord.TextChannel>}
      * @async
      */
     async askForBotSupportChannel(channel, userId) {
         try {
-            let botSupportChannel = (await Prompt.channelPrompt({prompt: 'What channel can the bot use to contact users when DMs are not available?', channel, userId})).first();
-            discordServices.channelIDs.botSupportChannel = botSupportChannel.id;
+            return (await Prompt.channelPrompt({prompt: 'What channel can the bot use to contact users when DMs are not available?', channel, userId})).first();
         } catch (error) {
             channel.send('<@' + userId + '> You can not cancel this command, please try again!').then(msg => msg.delete({timeout: 15000}));
-            await this.askForBotSupportChannel(channel, userId);
-        }
-    }
-
-    /**
-     * Will create the admin channels with the correct roles.
-     * @param {Discord.Guild} guild 
-     * @param {Discord.Role} adminRole 
-     * @param {Discord.Role} everyoneRole 
-     * @returns {Promise<Discord.TextChannel>} - the admin console channel
-     */
-    async createAdminChannels(guild, adminRole, everyoneRole) {
-        let adminCategory = await guild.channels.create('Admins', {
-            type: 'category',
-            permissionOverwrites: [
-                {
-                    id: adminRole.id,
-                    allow: 'VIEW_CHANNEL'
-                },
-                {
-                    id: everyoneRole.id,
-                    deny: ['VIEW_CHANNEL', 'SEND_MESSAGES', 'CONNECT']
-                }
-            ]
-        });
-
-        let adminConsoleChannel = await guild.channels.create('console', {
-            type: 'text',
-            parent: adminCategory,
-        });
-
-        let adminLogChannel = await guild.channels.create('logs', {
-            type: 'text',
-            parent: adminCategory,
-        });
-
-        discordServices.channelIDs.adminConsoleChannel = adminConsoleChannel.id;
-        discordServices.channelIDs.adminLogChannel = adminLogChannel.id;
-
-        return adminConsoleChannel;
-    }
-
-    /**
-     * Will set the verification process, and prep the server to use it.
-     * @param {Discord.TextChannel} channel 
-     * @param {Discord.Snowflake} userId 
-     * @param {CommandoGuild} guild 
-     * @param {Discord.Role} everyoneRole
-     * @param {Discord.Role} memberRole
-     */
-    async setVerification(channel, userId, guild, everyoneRole, memberRole) {
-        guild.setCommandEnabled('verify', true);
-        var guestRole;
-        try {
-            // ask for guest role
-            guestRole = await this.askOrCreate('guest', channel, userId, guild, '#969C9F');
-            guestRole.setMentionable(false);
-            guestRole.setPermissions(0); // no permissions, that is how it works
-        } catch (error) {
-            discordServices.sendMsgToChannel(channel, userId, 'You need to give a guest role! Please try again', 10);
-            return this.setVerification(channel, userId, guild, everyoneRole);
-        }
-
-        let welcomeCategory = await guild.channels.create('Welcome', {
-            type: 'category',
-            permissionOverwrites: [
-                {
-                    id: everyoneRole.id,
-                    allow: ['VIEW_CHANNEL', 'SEND_MESSAGES', 'READ_MESSAGE_HISTORY']
-                },
-                {
-                    id: memberRole.id,
-                    deny: ['VIEW_CHANNEL', 'SEND_MESSAGES', 'READ_MESSAGE_HISTORY']
-                },
-            ],
-        });
-
-        let welcomeChannel = await guild.channels.create('welcome', {
-            type: 'text',
-            parent: welcomeCategory,
-        });
-
-        // update welcome channel to not send messages
-        welcomeChannel.updateOverwrite(everyoneRole, {
-            SEND_MESSAGES: false,
-        });
-
-        let welcomeChannelSupport = await guild.channels.create('welcome-support', {
-            type: 'text',
-            parent: welcomeCategory,
-        });
-
-        const embed = new Discord.MessageEmbed().setTitle('Welcome to the ' + guild.name + ' Discord server!')
-            .setDescription('In order to verify that you have registered for ' + guild.name + ', please respond to the bot (me) via DM!')
-            .addField('Do you need assistance?', 'Head over to the welcome-support channel and ping the admins!')
-            .setColor(discordServices.colors.embedColor);
-        welcomeChannel.send(embed).then(msg => msg.pin());
-
-        discordServices.channelIDs.welcomeSupport = welcomeChannelSupport.id;
-        discordServices.channelIDs.welcomeChannel = welcomeChannel.id;
-        discordServices.roleIDs.guestRole = guestRole.id;
-    }
-
-    /**
-     * Will set the announcements from firebase.
-     * @param {Discord.TextChannel} channel 
-     * @param {Discord.Snowflake} userId 
-     */
-    async setAnnouncements(channel, userId) {
-        try {
-            let announcementChannel = (await Prompt.channelPrompt({prompt: 'What channel should announcements be sent to? If you don\'t have it, create it and come back, do not cancel.', channel, userId})).first();
-
-            // var to mark if gotten documents once
-            var isInitState = true;
-
-            // start query listener for announcements
-            nwFirebase.firestore().collection('Hackathons').doc('nwHacks2021').collection('Announcements').onSnapshot(querySnapshot => {
-                // exit if we are at the initial state
-                if (isInitState) {
-                    isInitState = false;
-                    return;
-                }
-
-                querySnapshot.docChanges().forEach(change => {
-                    if (change.type === 'added') {
-                        const embed = new Discord.MessageEmbed()
-                            .setColor(discordServices.colors.announcementEmbedColor)
-                            .setTitle('Announcement')
-                            .setDescription(change.doc.data()['content']);
-
-                        announcementChannel.send('<@&' + discordServices.roleIDs.attendeeRole + '>', { embed: embed });
-                    }
-                });
-            });
-        } catch (error) {
-            channel.send('<@' + userId + '> The announcement feature was canceled!').then(msg => msg.delete({ timeout: 60000 }));
+            return await this.askForBotSupportChannel(channel, userId);
         }
     }
 

--- a/commands/utility/ask.js
+++ b/commands/utility/ask.js
@@ -25,7 +25,7 @@ module.exports = class AskQuestion extends PermissionCommand {
     }
 
     // Run function -> command body
-    async runCommand(message, {question}) {
+    async runCommand(botGuild, message, {question}) {
 
         // if question is blank let user know via DM and exit
         if (question === '') {
@@ -33,15 +33,13 @@ module.exports = class AskQuestion extends PermissionCommand {
                                                                 'Like this: !ask This is a question');
             return;
         }
-
-        let botGuild = await BotGuild.findById(message.guild.id);        
         
         // get current channel
         var curChannel = message.channel;
 
         // message embed to be used for question
         const qEmbed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.questionEmbedColor)
+            .setColor(botGuild.colors.questionEmbedColor)
             .setTitle('Question from ' + message.author.username)
             .setDescription(question);
         

--- a/commands/utility/ask.js
+++ b/commands/utility/ask.js
@@ -2,6 +2,7 @@
 const PermissionCommand = require('../../classes/permission-command');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
+const BotGuild = require('../../db/botGuildDBObject');
 
 // Command export
 module.exports = class AskQuestion extends PermissionCommand {
@@ -20,10 +21,6 @@ module.exports = class AskQuestion extends PermissionCommand {
                     default: '',
                 }
             ],
-        },
-        {
-            roleID: discordServices.roleIDs.memberRole,
-            roleMessage: 'This command is only available for attendees!',
         });
     }
 
@@ -36,7 +33,8 @@ module.exports = class AskQuestion extends PermissionCommand {
                                                                 'Like this: !ask This is a question');
             return;
         }
-        
+
+        let botGuild = await BotGuild.findById(message.guild.id);        
         
         // get current channel
         var curChannel = message.channel;
@@ -85,7 +83,7 @@ module.exports = class AskQuestion extends PermissionCommand {
                             // if cancel then do nothing
                             if (response.content.toLowerCase() != 'cancel') {
                                 // if user has a mentor role, they get a special title
-                                if (discordServices.checkForRole(response.member, discordServices.roleIDs?.mentorRole)) {
+                                if (discordServices.checkForRole(response.member, botGuild.roleIDs?.mentorRole)) {
                                     msg.edit(msg.embeds[0].addField('🤓 ' + user.username + ' Responded:', response.content));
                                 } else {
                                     // add a field to the message embed with the response
@@ -118,7 +116,7 @@ module.exports = class AskQuestion extends PermissionCommand {
                 // remove emoji will remove the message
                 else if (reaction.emoji.name === '⛔') {
                     // check that user is staff
-                    if (discordServices.checkForRole(msg.guild.member(user), discordServices.roleIDs.staffRole)) {
+                    if (discordServices.checkForRole(msg.guild.member(user), botGuild.roleIDs.staffRole)) {
                         msg.delete();
                     } else {
                         discordServices.sendMessageToMember(user, 'Deleting a question is only available to staff!', true);

--- a/commands/utility/ask.js
+++ b/commands/utility/ask.js
@@ -81,7 +81,7 @@ module.exports = class AskQuestion extends PermissionCommand {
                             // if cancel then do nothing
                             if (response.content.toLowerCase() != 'cancel') {
                                 // if user has a mentor role, they get a special title
-                                if (discordServices.checkForRole(response.member, botGuild.roleIDs?.mentorRole)) {
+                                if (discordServices.checkForRole(response.member, botGuild.roleIDs.staffRole)) {
                                     msg.edit(msg.embeds[0].addField('🤓 ' + user.username + ' Responded:', response.content));
                                 } else {
                                     // add a field to the message embed with the response

--- a/commands/utility/report.js
+++ b/commands/utility/report.js
@@ -2,6 +2,7 @@
 const { Command } = require('discord.js-commando');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
+const BotGuild = require('../../db/botGuildDBObject');
 
 // Command export
 module.exports = class Report extends Command {
@@ -49,7 +50,7 @@ module.exports = class Report extends Command {
                 .setDescription(msg.content);
 
             // send embed with text message to ping admin
-            incomingReportChn.send('<@&' + discordServices.roleIDs.adminRole + '> Incoming Report', {embed: adminMsgEmbed});
+            incomingReportChn.send('<@&' + (await BotGuild.findById(message.guild.id)).roleIDs.adminRole + '> Incoming Report', {embed: adminMsgEmbed});
         })
         
     }

--- a/commands/utility/report.js
+++ b/commands/utility/report.js
@@ -57,7 +57,7 @@ module.exports = class Report extends Command {
                 .setDescription(msg.content);
 
             // send embed with text message to ping admin
-            incomingReportChn.send('<@&' + (await BotGuild.findById(message.guild.id)).roleIDs.adminRole + '> Incoming Report', {embed: adminMsgEmbed});
+            incomingReportChn.send('<@&' + botGuild.roleIDs.adminRole + '> Incoming Report', {embed: adminMsgEmbed});
         })
         
     }

--- a/commands/utility/report.js
+++ b/commands/utility/report.js
@@ -34,14 +34,14 @@ module.exports = class Report extends Command {
         var msgEmbed = await message.author.send(embed);
 
         // await response
-        msgEmbed.channel.awaitMessages(m => true, {max: 1}).then(msgs => {
+        msgEmbed.channel.awaitMessages(m => true, {max: 1}).then(async msgs => {
             var msg = msgs.first();
 
             msgEmbed.delete();
             message.author.send('Thank you for the report! Our admin team will look at it ASAP!');
 
             // send the report content to the admin report channel!
-            var incomingReportChn = message.guild.channels.resolve(discordServices.channelIDs.incomingReportChannel);
+            var incomingReportChn = await message.guild.channels.resolve(discordServices.channelIDs.incomingReportChannel);
 
             const adminMsgEmbed = new Discord.MessageEmbed()
                 .setColor(discordServices.colors.embedColor)

--- a/commands/utility/report.js
+++ b/commands/utility/report.js
@@ -18,10 +18,17 @@ module.exports = class Report extends Command {
     }
 
     async run (message) {
+        let botGuild = await BotGuild.findById(message.guild.id);
+
         discordServices.deleteMessage(message);
 
+        if (!botGuild.report.isEnabled) {
+            discordServices.sendMessageToMember(message.author, 'The report functionality is disabled for this guild.');
+            return;
+        }
+
         const embed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('Thank you for taking the time to report users who are not following server or MLH rules. You help makes our community safer!')
             .setDescription('Please use the format below, be as precise and accurate as possible. \n ' + 
                             'Everything you say will be 100% anonymous. We have no way of reaching back to you so again, be as detailed as possible!\n' + 
@@ -42,10 +49,10 @@ module.exports = class Report extends Command {
             message.author.send('Thank you for the report! Our admin team will look at it ASAP!');
 
             // send the report content to the admin report channel!
-            var incomingReportChn = await message.guild.channels.resolve(discordServices.channelIDs.incomingReportChannel);
+            var incomingReportChn = await message.guild.channels.resolve(botGuild.report.incomingReportChannelID);
 
             const adminMsgEmbed = new Discord.MessageEmbed()
-                .setColor(discordServices.colors.embedColor)
+                .setColor(botGuild.colors.embedColor)
                 .setTitle('There is a new report that needs your attention!')
                 .setDescription(msg.content);
 

--- a/commands/verification/attend.js
+++ b/commands/verification/attend.js
@@ -27,11 +27,11 @@ module.exports = class Attend extends PermissionCommand {
     }
 
     /**
-     * 
+     * Attends a member.
      * @param {Discord.Message} message 
      * @param {String} guildId 
      */
-    async runCommand(message, { guildId }) {
+    async runCommand(botGuild, message, { guildId }) {
         // check if the user needs to attend, else warn and return
         if (discordServices.checkForRole(message.author, discordServices.roleIDs.attendeeRole)) {
             discordServices.sendEmbedToMember(message.author, {

--- a/commands/verification/start-attend.js
+++ b/commands/verification/start-attend.js
@@ -3,6 +3,7 @@ const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const Prompt = require('../../classes/prompt');
 const Verification = require('../../classes/verification');
+const { Document } = require('mongoose');
 
 /**
  * StartAttend makes a new channel called #attend, or uses an existing channel of the user's choice, as the channel where the attend
@@ -30,11 +31,11 @@ module.exports = class StartAttend extends PermissionCommand {
      * If existsChannel is true, asks user to indicate the channel to use. Else asks user to indicate the category under which the
      * channel should be created, and then creates it. In both cases it will send an embed containing the instructions for hackers to 
      * check in.
+     * @param {Document} botGuild
      * @param {Discord.Message} message - message containing command
      */
-    async runCommand(message) {
+    async runCommand(botGuild, message) {
         var channel;
-        let botGuild = BotGuild.findById(message.guild.id);
 
         // register the attend command just in case its needed
         message.guild.setCommandEnabled('attend', true);
@@ -76,14 +77,15 @@ module.exports = class StartAttend extends PermissionCommand {
         let attendEmoji = '🔋';
 
         const embed = new Discord.MessageEmbed()
-            .setColor(discordServices.colors.embedColor)
+            .setColor(botGuild.colors.embedColor)
             .setTitle('Hey there!')
             .setDescription('In order to indicate that you are participating, please react to this message with ' + attendEmoji)
             .addField('Do you need assistance?', 'Head over to the support channel and ping the admins!')
         let embedMsg = await channel.send('<@&' + botGuild.roleIDs.memberRole + '>', {embed: embed});
         embedMsg.pin();
         embedMsg.react(attendEmoji);
-        discordServices.blackList.set(channel.id, 1000);
+        botGuild.blackList.set(channel.id, 1000);
+        botGuild.save();
         
         // reaction collector to attend hackers
         let embedMsgCollector = embedMsg.createReactionCollector((reaction, user) => !user.bot && reaction.emoji.name === attendEmoji);
@@ -92,7 +94,7 @@ module.exports = class StartAttend extends PermissionCommand {
             let member = message.guild.member(user.id);
 
             // check if user needs to attend
-            if (!discordServices.checkForRole(member, discordServices.roleIDs.attendeeRole)) {
+            if (!discordServices.checkForRole(member, botGuild.roleIDs.attendeeRole)) {
                    Verification.attend(member);
             } else {
                 discordServices.sendEmbedToMember(member, {

--- a/commands/verification/start-attend.js
+++ b/commands/verification/start-attend.js
@@ -34,6 +34,7 @@ module.exports = class StartAttend extends PermissionCommand {
      */
     async runCommand(message) {
         var channel;
+        let botGuild = BotGuild.findById(message.guild.id);
 
         // register the attend command just in case its needed
         message.guild.setCommandEnabled('attend', true);
@@ -69,7 +70,7 @@ module.exports = class StartAttend extends PermissionCommand {
             return;
         }
 
-        channel.updateOverwrite(discordServices.roleIDs.everyoneRole, { SEND_MESSAGES: false });
+        channel.updateOverwrite(botGuild.roleIDs.everyoneRole, { SEND_MESSAGES: false });
 
         //send embed with information and tagging hackers
         let attendEmoji = '🔋';
@@ -79,7 +80,7 @@ module.exports = class StartAttend extends PermissionCommand {
             .setTitle('Hey there!')
             .setDescription('In order to indicate that you are participating, please react to this message with ' + attendEmoji)
             .addField('Do you need assistance?', 'Head over to the support channel and ping the admins!')
-        let embedMsg = await channel.send('<@&' + discordServices.roleIDs.hackerRole + '>', {embed: embed});
+        let embedMsg = await channel.send('<@&' + botGuild.roleIDs.memberRole + '>', {embed: embed});
         embedMsg.pin();
         embedMsg.react(attendEmoji);
         discordServices.blackList.set(channel.id, 1000);

--- a/commands/verification/verify.js
+++ b/commands/verification/verify.js
@@ -32,7 +32,7 @@ module.exports = class Verify extends PermissionCommand {
     }
 
     /**
-     * 
+     * DOES NOT WORK !!!! TODO REMOVE OR ADD ABILITY TO GIVE GUILD ID FOR IT TO WORK!
      * @param {Discord.Message} message 
      * @param {String} email 
      */
@@ -62,6 +62,7 @@ module.exports = class Verify extends PermissionCommand {
             return;
         }
         let member = guild.member(message.author.id);
+        let botGuild = await BotGuild.findById(guild.id);
 
         // Call the verify function
         try {
@@ -72,7 +73,5 @@ module.exports = class Verify extends PermissionCommand {
                 description: 'Email provided is not valid!'
             }, true);
         }
-
     }
-
 };

--- a/commands/verification/verify.js
+++ b/commands/verification/verify.js
@@ -3,6 +3,7 @@ const PermissionCommand = require('../../classes/permission-command');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const Verification = require('../../classes/verification');
+const { Document } = require('mongoose');
 
 // Command export
 module.exports = class Verify extends PermissionCommand {
@@ -33,10 +34,11 @@ module.exports = class Verify extends PermissionCommand {
 
     /**
      * DOES NOT WORK !!!! TODO REMOVE OR ADD ABILITY TO GIVE GUILD ID FOR IT TO WORK!
+     * @param {Document} botGuild
      * @param {Discord.Message} message 
      * @param {String} email 
      */
-    async runCommand(message, { email, guildId }) {
+    async runCommand(botGuild, message, { email, guildId }) {
 
         // check if the user needs to verify, else warn and return
         if (!discordServices.checkForRole(member, discordServices.roleIDs.guestRole)) {
@@ -62,7 +64,6 @@ module.exports = class Verify extends PermissionCommand {
             return;
         }
         let member = guild.member(message.author.id);
-        let botGuild = await BotGuild.findById(guild.id);
 
         // Call the verify function
         try {

--- a/db/botGuildDBObject.js
+++ b/db/botGuildDBObject.js
@@ -22,7 +22,7 @@ const BotGuildSchema = new Schema({
         },
     },
 
-    channelsIDs: {
+    channelIDs: {
         adminConsole: {
             type: String,
         },

--- a/db/botGuildDBObject.js
+++ b/db/botGuildDBObject.js
@@ -2,7 +2,11 @@ const { Schema, model } = require('mongoose');
 
 const BotGuildClass = require('../classes/bot-guild');
 
+/**
+ * @class BotGuild
+ */
 const BotGuildSchema = new Schema({
+
     roleIDs: {
         memberRole: {
             type: String,

--- a/db/botGuildDBObject.js
+++ b/db/botGuildDBObject.js
@@ -1,0 +1,146 @@
+const { Schema, model } = require('mongoose');
+
+const BotGuildClass = require('../classes/bot-guild');
+
+const BotGuildSchema = new Schema({
+    roleIDs: {
+        memberRole: {
+            type: String,
+        },
+        staffRole: {
+            type: String,
+        },
+        adminRole: {
+            type: String,
+        },
+        everyoneRole: {
+            type: String,
+        },
+    },
+
+    channelsIDs: {
+        adminConsole: {
+            type: String,
+        },
+        adminLog: {
+            type: String,
+        },
+        botSupportChannel: {
+            type: String,
+        },
+    },
+
+    verification: {
+        isEnabled: {
+            type: Boolean,
+            default: false,
+        },
+        guestRoleID: {
+            type: String,
+        },
+        welcomeChannelID: {
+            type: String,
+        },
+        welcomeSupportChannelID: {
+            type: String,
+        },
+    },
+
+    attendance: {
+        isEnabled: {
+            type: Boolean,
+            default: false,
+        },
+        attendeeRoleID: {
+            type: String,
+        },
+    },
+
+    stamps: {
+        isEnabled: {
+            type: Boolean,
+            default: false,
+        },
+        stampRoleIDs: {
+            type: Map,
+            default: new Map(),
+        },
+        stampCollectionTime: {
+            type: Number,
+            default: 60,
+        },
+    },
+
+    report: {
+        isEnabled: {
+            type: Boolean,
+            default: false,
+        },
+        incomingReportChannelID: {
+            type: String,
+        },
+    },
+
+    announcement: {
+        isEnabled: {
+            type: Boolean,
+            default: false,
+        },
+        announcementChannelID: {
+            type: String,
+        },
+    },
+
+    blackList: {
+        type: Map,
+        default: new Map(),
+    },
+
+    caves: {
+        type: Map,
+        default: new Map(),
+    },
+
+    colors: {
+        embedColor: {
+            type: String,
+            default: '#26fff4',
+        },
+        questionEmbedColor: {
+            type: String,
+            default: '#f4ff26',
+        },
+        announcementEmbedColor: {
+            type: String,
+            default: '#9352d9',
+        },
+        tfTeamEmbedColor: {
+            type: String,
+            default: '#60c2e6',
+        },
+        tfHackerEmbedColor: {
+            type: String,
+            default: '#d470cd',
+        },
+        specialDMEmbedColor: {
+            type: String,
+            default: '#fc6b03',
+        }, 
+    },
+
+    _id: {
+        type: String,
+        required: true,
+    },
+
+    isSetUpComplete: {
+        type: Boolean,
+        default: false,
+    }
+});
+
+BotGuildSchema.loadClass(BotGuildClass);
+
+const BotGuild = model('BotGuild', BotGuildSchema);
+
+module.exports = BotGuild;

--- a/db/mongoUtil.js
+++ b/db/mongoUtil.js
@@ -1,0 +1,41 @@
+const { MongoClient, Db,  } = require('mongodb');
+const mongoose = require('mongoose');
+
+const url = 'mongodb+srv://dev-user:' + process.env.MONGODBPASSWORD + '@cluster-dev.j87rm.mongodb.net/test?retryWrites=true&w=majority&useNewUrlParser=true&useUnifiedTopology=true'
+const mongooseUrl = 'mongodb+srv://dev-user:' + process.env.MONGODBPASSWORD + '@cluster-dev.j87rm.mongodb.net/data';
+/** @type {Db} */
+var _db;
+
+module.exports = {
+
+    /**
+     * Starts a connection to MongoDB
+     */
+    async connect() {
+        const mongoClient = new MongoClient(url);
+
+        await mongoClient.connect()
+
+        console.log('Connected to mongoDB');
+        _db = mongoClient.db('data');
+    },
+
+    /**
+     * @returns {Db}
+     */
+    getDb() {
+        return _db;
+    },
+
+    /**
+     * @returns {Collection}
+     */
+    getBotGuildCol() {
+        return _db.collection('botGuilds');
+    },
+
+    async mongooseConnect() {
+        let db = await mongoose.connect(mongooseUrl, {useNewUrlParser: true, useUnifiedTopology: true});
+    }
+
+}

--- a/dev_config.json
+++ b/dev_config.json
@@ -1,26 +1,26 @@
 {
     "adminRoleID" : "738491577596641311",
-    "adminConsoleID" : "808454476116787230",
-    "adminLogsID" : "743197503884755045",
+    "adminConsoleID" : "811741804406767666",
+    "adminLogsID" : "811741805077856316",
     "staffRoleID" : "738519363904077916",
     "memberRoleID" : "808409937373298700",
     "everyoneRoleID" : "738475671977722058",
 
     "isVerificationOn" : true,
     "guestRoleID" : "778651193362481213",
-    "welcomeChannelID" : "808454570418110484",
-    "welcomeChannelSupportID" : "808454571172954202",
+    "welcomeChannelID" : "811741918253547540",
+    "welcomeChannelSupportID" : "811741919008784454",
 
     "isAttendanceOn" : true,
-    "attendeeRoleID" : "742896999556448357",
+    "attendeeRoleID" : "738519785028976741",
 
     "isAnnouncementOn" : false,
 
     "isStampOn" : true,
     "stamps" : [
-        "808451225930039316",
-        "808451226148405259",
-        "808451227230535700"
+        "811743390572085269",
+        "811743394165817344",
+        "811743395001270312"
     ],
 
     "botSupportChannelID" : "806586723483385857",

--- a/discord-services.js
+++ b/discord-services.js
@@ -179,17 +179,6 @@ async function replyAndDelete(message, reply) {
 module.exports.replyAndDelete = replyAndDelete;
 
 /**
- * True if channel is admin console channel
- * @param {Discord.Channel} channel - channel to check
- * @returns {Promise<Boolean>}
- * @async
- */
-async function isAdminConsole(channel) {
-    return channel.id === (await (BotGuild.findById(channel.guild.id))).channelIDs.adminConsole;
-}
-module.exports.isAdminConsole = isAdminConsole;
-
-/**
  * Deletes a message if the message hasn't been deleted already
  * @param {Discord.Message} message - the message to delete
  * @param {Number} timeout - the time to wait in milliseconds

--- a/index.js
+++ b/index.js
@@ -164,11 +164,15 @@ process.on('exit', () => {
 });
 
 bot.on('message', async message => {
+    let botGuild = await BotGuild.findById(message.guild.id);
+
     // Deletes all messages to any channel in the black list with the specified timeout
     // this is to make sure that if the message is for the bot, it is able to get it
     // bot and staff messages are not deleted
-    if (discordServices.blackList.has(message.channel.id)) {
-        if (!message.author.bot && !discordServices.checkForRole(message.member, discordServices.roleIDs.staffRole)) {
+    if (true || botGuild.blackList.has(message.channel.id)) {
+        
+        
+        if (!message.author.bot && !discordServices.checkForRole(message.member, botGuild.roleIDs.staffRole)) {
             (new Promise(res => setTimeout(res, discordServices.blackList.get(message.channel.id)))).then(() => discordServices.deleteMessage(message));
         }
     }
@@ -195,6 +199,8 @@ bot.login(config.token).catch(console.error);
 async function greetNewMember(member) {
     let verifyEmoji = '🍀';
 
+    let botGuild = await BotGuild.findById(member.guild.id);
+
     var embed = new Discord.MessageEmbed()
         .setTitle('Welcome to the nwHacks 2021 Server!')
         .setDescription('We are very excited to have you here!')
@@ -202,13 +208,13 @@ async function greetNewMember(member) {
         .addField('Want to learn more about what I can do?', 'Use the !help command anywhere and I will send you a message!')
         .setColor(discordServices.colors.embedColor);
 
-    if (discordServices.roleIDs?.guestRole) embed
-        .addField('Gain more access by verifying yourself!', 'React to this message with ' + verifyEmoji + ' and follow my instructions!\n');
+    if (botGuild.verification.isEnabled) embed.addField('Gain more access by verifying yourself!', 'React to this message with ' + verifyEmoji + ' and follow my instructions!');
+    
     let msg = await member.send(embed);
 
     // if verification is on then give guest role and let user verify
-    if (discordServices.roleIDs?.guestRole) {
-        discordServices.addRoleToMember(member, discordServices.roleIDs.guestRole);
+    if (botGuild.verification.isEnabled) {
+        discordServices.addRoleToMember(member, botGuild.roleIDs.guestRole);
 
         msg.react(verifyEmoji);
         let verifyCollector = msg.createReactionCollector((reaction, user) => !user.bot && reaction.emoji.name === verifyEmoji);
@@ -236,7 +242,7 @@ async function greetNewMember(member) {
     }
     // if verification is off, then just ive member role
     else {
-        discordServices.addRoleToMember(member, discordServices.roleIDs.memberRole);
+        discordServices.addRoleToMember(member, botGuild.roleIDs.memberRole);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -164,18 +164,21 @@ process.on('exit', () => {
 });
 
 bot.on('message', async message => {
-    let botGuild = await BotGuild.findById(message.guild.id);
+    if (message?.guild) {
+        let botGuild = await BotGuild.findById(message.guild.id);
 
-    // Deletes all messages to any channel in the black list with the specified timeout
-    // this is to make sure that if the message is for the bot, it is able to get it
-    // bot and staff messages are not deleted
-    if (true || botGuild.blackList.has(message.channel.id)) {
-        
-        
-        if (!message.author.bot && !discordServices.checkForRole(message.member, botGuild.roleIDs.staffRole)) {
-            (new Promise(res => setTimeout(res, discordServices.blackList.get(message.channel.id)))).then(() => discordServices.deleteMessage(message));
+        // Deletes all messages to any channel in the black list with the specified timeout
+        // this is to make sure that if the message is for the bot, it is able to get it
+        // bot and staff messages are not deleted
+        if (botGuild.blackList.has(message.channel.id)) {
+            if (!message.author.bot && !discordServices.checkForRole(message.member, botGuild.roleIDs.staffRole)) {
+                (new Promise(res => setTimeout(res, botGuild.blackList.get(message.channel.id)))).then(() => discordServices.deleteMessage(message));
+            }
         }
     }
+
+
+    
 
 });
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const discordServices = require('./discord-services');
 const Prompt = require('./classes/prompt');
 const mongoUtil = require('./db/mongoUtil');
 const BotGuild = require('./db/botGuildDBObject');
+const { Document } = require('mongoose');
+const Verification = require('./classes/verification');
 
 const admin = require('firebase-admin');
 
@@ -184,10 +186,11 @@ bot.on('message', async message => {
 
 // If someone joins the server they get the guest role!
 bot.on('guildMemberAdd', async member => {
+    let botGuild = await BotGuild.findById(member.guild.id);
     try {
-        await greetNewMember(member);
+        await greetNewMember(member, botGuild);
     } catch (error) {
-        await fixDMIssue(error, member);
+        await fixDMIssue(error, member, botGuild);
     }
 });
 
@@ -197,12 +200,11 @@ bot.login(config.token).catch(console.error);
 /**
  * Greets a member!
  * @param {Discord.GuildMember} member - the member to greet
+ * @param {Document} botGuild
  * @throws Error if the user has server DMs off
  */
-async function greetNewMember(member) {
+async function greetNewMember(member, botGuild) {
     let verifyEmoji = '🍀';
-
-    let botGuild = await BotGuild.findById(member.guild.id);
 
     var embed = new Discord.MessageEmbed()
         .setTitle('Welcome to the nwHacks 2021 Server!')
@@ -253,9 +255,10 @@ async function greetNewMember(member) {
  * Will let the member know how to fix their DM issue.
  * @param {Error} error - the error
  * @param {Discord.GuildMember} member - the member with the error
+ * @param {Document} botGuild
  * @throws Error if the given error is not a DM error
  */
-async function fixDMIssue(error, member) {
+async function fixDMIssue(error, member, botGuild) {
     if (error.code === 50007) {
         let botGuild = await BotGuild.findById(member.guild.id);
 

--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ async function greetNewMember(member) {
         .setDescription('We are very excited to have you here!')
         .addField('Have a question?', 'Go to the welcome-assistance channel to talk with our staff!')
         .addField('Want to learn more about what I can do?', 'Use the !help command anywhere and I will send you a message!')
-        .setColor(discordServices.colors.embedColor);
+        .setColor(botGuild.colors.embedColor);
 
     if (botGuild.verification.isEnabled) embed.addField('Gain more access by verifying yourself!', 'React to this message with ' + verifyEmoji + ' and follow my instructions!');
     
@@ -217,7 +217,7 @@ async function greetNewMember(member) {
 
     // if verification is on then give guest role and let user verify
     if (botGuild.verification.isEnabled) {
-        discordServices.addRoleToMember(member, botGuild.roleIDs.guestRole);
+        discordServices.addRoleToMember(member, botGuild.verification.guestRoleID);
 
         msg.react(verifyEmoji);
         let verifyCollector = msg.createReactionCollector((reaction, user) => !user.bot && reaction.emoji.name === verifyEmoji);
@@ -257,7 +257,9 @@ async function greetNewMember(member) {
  */
 async function fixDMIssue(error, member) {
     if (error.code === 50007) {
-        let channelID = discordServices.channelIDs?.welcomeSupport || discordServices.channelIDs.botSupportChannel;
+        let botGuild = await BotGuild.findById(member.guild.id);
+
+        let channelID = botGuild.verification?.welcomeSupportChannelID || botGuild.channelIDs.botSupportChannel;
 
         member.guild.channels.resolve(channelID).send('<@' + member.id + '> I couldn\'t reach you :(.' +
             '\n* Please turn on server DMs, explained in this link: https://support.discord.com/hc/en-us/articles/217916488-Blocking-Privacy-Settings-' +

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ require('dotenv-flow').config();
 
 // Firebase requirements
 var firebase = require('firebase/app');
+const mongoUtil = require('./db/mongoUtil');
 
 const admin = require('firebase-admin');
 
@@ -64,6 +65,19 @@ bot.registry
 bot.once('ready', async () => {
     console.log(`Logged in as ${bot.user.tag}!`);
     bot.user.setActivity('Ready to hack!');
+
+    await mongoUtil.mongooseConnect();
+
+    bot.guilds.cache.forEach(async (guild, key, guilds) => {
+        let botGuild = await BotGuild.findById(guild.id);
+
+        if (!botGuild) {
+            BotGuild.create({
+                _id: guild.id,
+            });
+        }
+
+    });
 });
 
 bot.on('guildCreate', /** @param {Commando.CommandoGuild} guild */(guild) => {
@@ -71,7 +85,9 @@ bot.on('guildCreate', /** @param {Commando.CommandoGuild} guild */(guild) => {
         if (!group.guarded) guild.setGroupEnabled(group, false);
     });
 
-    console.log('inside guild create!');
+    BotGuild.create({
+        _id: guild.id,
+    });
 });
 
 // Listeners for the bot

--- a/package-lock.json
+++ b/package-lock.json
@@ -464,9 +464,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/mongodb": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.7.tgz",
-      "integrity": "sha512-47P64kbkXarlleSMzSrRG04uzY+Dr3xAilOiqRIsqj/sZrmq6cUMx8njydY/iWMqi8IdE9ojFQl/X3ou9EsAlQ==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.8.tgz",
+      "integrity": "sha512-8qNbL5/GFrljXc/QijcuQcUMYZ1iWNcqnJ6tneROwbfU0LsAjQ9bmq3aHi5lWXM4cyBPd2F/n9INAk/pZZttHw==",
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -450,10 +450,27 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "optional": true
     },
+    "@types/bson": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
+      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
+    "@types/mongodb": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.7.tgz",
+      "integrity": "sha512-47P64kbkXarlleSMzSrRG04uzY+Dr3xAilOiqRIsqj/sZrmq6cUMx8njydY/iWMqi8IdE9ojFQl/X3ou9EsAlQ==",
+      "requires": {
+        "@types/bson": "*",
+        "@types/node": "*"
+      }
     },
     "@types/node": {
       "version": "12.19.7",
@@ -505,6 +522,25 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
     },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "bson": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -551,6 +587,11 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
       "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -575,6 +616,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "dicer": {
       "version": "0.3.0",
@@ -646,6 +692,19 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1",
         "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "ecdsa-sig-formatter": {
@@ -1064,8 +1123,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "optional": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-obj": {
       "version": "2.0.0",
@@ -1094,6 +1152,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "optional": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -1199,6 +1262,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "kareem": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
+      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -1266,6 +1334,12 @@
         "semver": "^6.0.0"
       }
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "mime": {
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
@@ -1289,6 +1363,80 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "optional": true
+    },
+    "mongodb": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.4.tgz",
+      "integrity": "sha512-Y+Ki9iXE9jI+n9bVtbTOOdK0B95d6wVGSucwtBkvQ+HIvVdTCfpVRp01FDC24uhC/Q2WXQ8Lpq3/zwtB5Op9Qw==",
+      "requires": {
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      }
+    },
+    "mongoose": {
+      "version": "5.11.17",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.11.17.tgz",
+      "integrity": "sha512-qggwwv+oTsjvlto9fhq17l2Mojl5Gn8GN7NxnaLjsZbjT4O5ONtKtGtymHZ23viGrlHn6rNFMJEnEql2G6tyrg==",
+      "requires": {
+        "@types/mongodb": "^3.5.27",
+        "bson": "^1.1.4",
+        "kareem": "2.3.2",
+        "mongodb": "3.6.4",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.8.3",
+        "mquery": "3.2.4",
+        "ms": "2.1.2",
+        "regexp-clone": "1.0.0",
+        "safe-buffer": "5.2.1",
+        "sift": "7.0.1",
+        "sliced": "1.0.1"
+      }
+    },
+    "mongoose-legacy-pluralize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
+    },
+    "mpath": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.3.tgz",
+      "integrity": "sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA=="
+    },
+    "mquery": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.4.tgz",
+      "integrity": "sha512-uOLpp7iRX0BV1Uu6YpsqJ5b42LwYnmu0WeF/f8qgD/On3g0XDaQM6pfn0m6UxO6SM8DioZ9Bk6xxbWIGHm2zHg==",
+      "requires": {
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
+        "regexp-clone": "^1.0.0",
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
     },
     "ms": {
       "version": "2.1.2",
@@ -1336,6 +1484,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.2.tgz",
       "integrity": "sha512-I+nkWY212lJ500jLe4tN9tWO7nRiBAVdMv76P9kffZjYhw20raMlW1HSSvS+MLXC9MmbNZCazMrAr+5jEEgTuw=="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise-polyfill": {
       "version": "8.1.3",
@@ -1391,20 +1544,56 @@
       }
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "optional": true,
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
+    },
+    "regexp-clone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
     },
     "require-all": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/require-all/-/require-all-3.0.0.tgz",
       "integrity": "sha1-Rz1JcEvjEBFc4ST3c4Ox69hnExI="
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "retry": {
       "version": "0.12.0",
@@ -1431,6 +1620,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1441,17 +1639,36 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
+    "sift": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "optional": true
     },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+    },
     "snakeize": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
       "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0=",
       "optional": true
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "stream-events": {
       "version": "1.0.5",
@@ -1474,12 +1691,18 @@
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "optional": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "stubs": {
@@ -1537,8 +1760,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "optional": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "firebase": "^7.19.0",
     "firebase-admin": "^9.5.0",
     "jsonfile": "^6.1.0",
-    "lokijs": "^1.5.11"
+    "lokijs": "^1.5.11",
+    "mongodb": "^3.6.4",
+    "mongoose": "^5.11.17"
   }
 }


### PR DESCRIPTION
HUGE CHANGE WILL BREAK PAST VERSIONS

This PR closes #120 by creating the botGuild class and using MongoDB and mongoose to persist this data.

### botGuild Class
The botGuild class holds data used by the bot for each guild that was previously kept by discordServices.
There are a few required fields for the bot to work that botGuild must have:
- admin console ID
- admin log ID
- admin role ID
- staff role ID
- member role ID
- bot support channel ID

All other information for verification, attendance, report, stamps, etc is optional and extra.
As mentioned the botGuild class is mapped via mongoose using a schema to use the ODM with MongoDB. The BotGuild class still holds all the methods and static properties that are then loaded into the mongoose model.

### New Servers
When the bot joins a new server, the bot will create a botGuild for that server and lock all commands except any locked groups, at this point only the essential group.
For all other commands to be available, the user must run `!botinit` and set up the bot. 

### Data persistence
With this update, when developing the bot, the basic guild data will persist and won't need to be set up.
Each botGuilld is mapped with its guild ID. To get a botGuild document you can do `await BotGuild.findById(guild.id);`. Be advised that there is no autocompletion for the properties, but you can take a look at the db/botGuildDBObject.js file to see all the available properties.
This opens the possibility to use MongoDB to persist other data like cave information, team formation, and roulette information, etc.

### Known Bugs
Verify and Attend commands will not work because they need to use botGuild data, but there is no way of getting a guild ID from that command since it's DM only. These commands should not be used and instead use start-attend and the verification sent to users when they join the server.