### PR TITLE
Activity permissions

### DIFF
--- a/commands/a_activity/archive.js
+++ b/commands/a_activity/archive.js
@@ -27,26 +27,23 @@ module.exports = class InitAmongUs extends ActivityCommand {
         var archiveCategory = await message.guild.channels.cache.find(channel => channel.type === 'category' && channel.name === '💼archive');
 
         if (archiveCategory === undefined) {
-            
+            let overwrites = [
+                {
+                    id: discordServices.roleIDs.everyoneRole,
+                    deny: ['VIEW_CHANNEL']
+                },
+                {
+                    id: discordServices.roleIDs.staffRole,
+                    allow: ['VIEW_CHANNEL']
+                }];
+            this.permissions.each(role => overwrites.push({ id: role.id, allow: ['VIEW_CHANNEL'] }));
+
             // position is used to create archive at the very bottom!
             var position = (await message.guild.channels.cache.filter(channel => channel.type === 'category')).array().length;
             archiveCategory = await message.guild.channels.create('💼archive', {
                 type: 'category', 
                 position: position + 1,
-                permissionOverwrites: discordServices.roleIDs?.attendeeRole ? [
-                    {
-                        id: discordServices.roleIDs.everyoneRole,
-                        deny: ['VIEW_CHANNEL'],
-                    },
-                    {
-                        id: discordServices.roleIDs.attendeeRole,
-                        allow: ['VIEW_CHANNEL'],
-                    },
-                    {
-                        id: discordServices.roleIDs.staffRole,
-                        allow: ['VIEW_CHANNEL'],
-                    }
-                ] : []
+                permissionOverwrites: overwrites
             });
         }
 

--- a/commands/a_activity/new-activity.js
+++ b/commands/a_activity/new-activity.js
@@ -3,7 +3,7 @@ const PermissionCommand = require('../../classes/permission-command');
 const discordServices = require('../../discord-services');
 const Discord = require('discord.js');
 const Activity = require('../../classes/activity');
-const { numberPrompt } = require('../../classes/prompt');
+const { numberPrompt, rolePrompt } = require('../../classes/prompt');
 
 // Command export
 module.exports = class NewActivity extends PermissionCommand {
@@ -32,7 +32,8 @@ module.exports = class NewActivity extends PermissionCommand {
 
     async runCommand(message, {activityName}) {
 
-        let activity = await new Activity(activityName, message.guild).init();
+        let allowedRoles = await rolePrompt({ prompt: 'What roles, aside from Staff, will be allowed to view this activity?', channel: message.channel, userId: message.author.id });
+        let activity = await new Activity(activityName, message.guild, allowedRoles).init();
 
         // report success of activity creation
         discordServices.replyAndDelete(message,'Activity session named: ' + activity.name + ' created successfully. Any other commands will require this name as paramter.');
@@ -138,7 +139,7 @@ module.exports = class NewActivity extends PermissionCommand {
                 activity.state.isAmongUs = true;
                 await activity.addLimitToVoiceChannels(12);
                 commandRegistry.findCommands('init-among-us', true)[0].runActivityCommand(message, activity, { numOfChannels: 3 });
-                activity.changeVoiceChannelPermissions(true);
+                //activity.changeVoiceChannelPermissions(true);
             } else if (emojiName === emojis[14]) {
                 commandRegistry.findCommands('archive', true)[0].runActivityCommand(message, activity);
                 msgConsole.delete({timeout: 3000});

--- a/commands/a_activity/new-activity.js
+++ b/commands/a_activity/new-activity.js
@@ -31,8 +31,13 @@ module.exports = class NewActivity extends PermissionCommand {
     }
 
     async runCommand(message, {activityName}) {
-
-        let allowedRoles = await rolePrompt({ prompt: 'What roles, aside from Staff, will be allowed to view this activity?', channel: message.channel, userId: message.author.id });
+        let allowedRoles;
+        try {
+            allowedRoles = await rolePrompt({ prompt: 'What roles, aside from Staff, will be allowed to view this activity? (Type "cancel" if none)',
+                channel: message.channel, userId: message.author.id });
+        } catch (error) {
+            allowedRoles = new Discord.Collection();
+        }
         let activity = await new Activity(activityName, message.guild, allowedRoles).init();
 
         // report success of activity creation


### PR DESCRIPTION
When Admin creates an activity, it asks Admin for what roles can view the activity aside from Staff. As long as the role has server-wide view channel and send message permissions they will be allowed to view the activity channels. (Edit: JK I think as long as they have both memberRole and the mentioned role they can see it). For workshops, it asks Admin who can view the TA channels aside from Staff and gives those roles permissions accordingly.