### PR TITLE
Stamp command block

### DIFF
--- a/classes/activity-manager.js
+++ b/classes/activity-manager.js
@@ -152,9 +152,13 @@ class ActivityManager {
      * @param {Discord.GuildMember} member - the member to add the new role to
      * @param {String} activityName - the name of the activity
      * @param {BotGuildModel} botGuild
-     * @private
+     * @throws Error if the botGuild has stamps disabled
      */
     static parseRole(member, activityName, botGuild) {
+        if (!botGuild.stamps.isEnabled) {
+            throw Error(`Stamp system is turned of for guild ${botGuild._id} but I was asked to parse a role for member ${member.id} for activity ${activityName}.`);
+        }
+
         let role = member.roles.cache.find(role => botGuild.stamps.stampRoleIDs.has(role.id));
 
         if (role === undefined) {

--- a/classes/activity-manager.js
+++ b/classes/activity-manager.js
@@ -156,6 +156,7 @@ class ActivityManager {
      */
     static parseRole(member, activityName, botGuild) {
         if (!botGuild.stamps.isEnabled) {
+            winston.loggers.get(botGuild._id).error(`Stamp system is turned of for guild ${botGuild._id} but I was asked to parse a role for member ${member.id} for activity ${activityName}.`, { event: "Activity Manager" });
             throw Error(`Stamp system is turned of for guild ${botGuild._id} but I was asked to parse a role for member ${member.id} for activity ${activityName}.`);
         }
 

--- a/classes/bot-guild.d.ts
+++ b/classes/bot-guild.d.ts
@@ -59,6 +59,11 @@ interface BotGuild extends Document {
         announcementChannelID: String,
     },
 
+    ask: {
+        /** @required */
+        isEnabled: Boolean,
+    },
+
     /**
      * This is some text
      */

--- a/classes/bot-guild.js
+++ b/classes/bot-guild.js
@@ -156,10 +156,6 @@ module.exports = class BotGuild {
 
         this.isSetUpComplete = true;
 
-        client.registry.groups.forEach((group, key, map) => {
-            if (group.name.startsWith('a_')) guild.setGroupEnabled(group, true);
-        });
-
         winston.loggers.get(this._id).event(`The botGuild has run the ready up function.`, {event: "Bot Guild"});
 
         return this;
@@ -312,6 +308,7 @@ module.exports = class BotGuild {
         /** @type {CommandoGuild} */
         let guild = await client.guilds.fetch(this._id);
         guild.setCommandEnabled('start-attend', true);
+        guild.setCommandEnabled('attend', true);
 
         winston.loggers.get(this._id).event(`The botGuild has set up the attendance functionality. Attendee role id is ${attendeeRoleID}`, {event: "Bot Guild"});
         return this;
@@ -434,7 +431,31 @@ module.exports = class BotGuild {
     async setUpAsk(client) {
         /** @type {CommandoGuild} */
         let guild = await client.guilds.fetch(this._id);
+        this.ask.isEnabled = true;
         guild.setCommandEnabled('ask', true);
         winston.loggers.get(this._id).event(`The botGuild has enabled the ask command!`, {event: "Bot Guild"});
+    }
+
+    /**
+     * Will enable and disable the appropriate commands by looking at what is enabled in the botGuild.
+     * @param {CommandoClient} client
+     * @async 
+     */
+    async setCommandStatus(client) {
+        /** @type {CommandoGuild} */
+        let guild = await client.guilds.fetch(this._id);
+        if (this.verification.isEnabled) guild.setCommandEnabled('verify', true);
+        if (this.attendance.isEnabled) {
+            guild.setCommandEnabled('start-attend', true);
+            guild.setCommandEnabled('attend', true);
+        }
+        if (this.stamps.isEnabled) guild.setGroupEnabled('stamps', true);
+        if (this.report.isEnabled) guild.setCommandEnabled('report', true);
+        if (this.ask.isEnabled) guild.setCommandEnabled('ask', true);
+        if (this.isSetUpComplete) {
+            client.registry.groups.forEach((group, key, map) => {
+                if (group.name.startsWith('a_')) guild.setGroupEnabled(group, true);
+            });
+        }
     }
 }

--- a/commands/a_activity/init-workshop.js
+++ b/commands/a_activity/init-workshop.js
@@ -113,7 +113,8 @@ module.exports = class InitWorkshop extends ActivityCommand {
                 reaction.users.remove(user.id);
 
                 if (emojiName === emojis[0]) {
-                    commandRegistry.findCommands('distribute-stamp', true)[0].runCommand(botGuild, message, activity, { timeLimit: botGuild.stamps.stampCollectionTime });
+                    if (botGuild.stamps.isEnabled) commandRegistry.findCommands('distribute-stamp', true)[0].runCommand(botGuild, message, activity, { timeLimit: botGuild.stamps.stampCollectTime });
+                    else discordServices.sendMsgToChannel(message.channel, user.id, "The distribute stamp command is not available because stamps are disabled in this server.");
                 } else if (emojiName === emojis[1]) {
                     commandRegistry.findCommands('workshop-polls', true)[0].runCommand(botGuild, message, activity, { questionType: 'speed' });
                 } else if (emojiName === emojis[2]) {

--- a/commands/a_activity/new-activity.js
+++ b/commands/a_activity/new-activity.js
@@ -141,7 +141,8 @@ module.exports = class NewActivity extends PermissionCommand {
             } else if (emojiName === emojis[8]) {
                 commandRegistry.findCommands('shuffle-mentors', true)[0].runActivityCommand(botGuild, message, activity);
             } else if (emojiName === emojis[9]) {
-                commandRegistry.findCommands('distribute-stamp', true)[0].runCommand(botGuild, message, activity, { timeLimit: botGuild.stamps.stampCollectTime });
+                if (botGuild.stamps.isEnabled) commandRegistry.findCommands('distribute-stamp', true)[0].runCommand(botGuild, message, activity, { timeLimit: botGuild.stamps.stampCollectTime });
+                else discordServices.sendMsgToChannel(message.channel, user.id, "The distribute stamp command is not available because stamps are disabled in this server.");
             } else if (emojiName === emojis[10]) {
                 commandRegistry.findCommands('workshop-polls',true)[0].runCommand(botGuild, message, activity, { questionType: 'speed' });
             } else if (emojiName === emojis[11]) {
@@ -152,7 +153,6 @@ module.exports = class NewActivity extends PermissionCommand {
                 activity.state.isAmongUs = true;
                 await activity.addLimitToVoiceChannels(12);
                 commandRegistry.findCommands('init-among-us', true)[0].runActivityCommand(botGuild, message, activity, { numOfChannels: 3 });
-                //activity.changeVoiceChannelPermissions(true);
             } else if (emojiName === emojis[14]) {
                 commandRegistry.findCommands('archive', true)[0].runActivityCommand(botGuild, message, activity);
                 msgConsole.delete({timeout: 3000});

--- a/commands/essentials/init-bot.js
+++ b/commands/essentials/init-bot.js
@@ -200,6 +200,7 @@ module.exports = class InitBot extends Command {
                 let numberOfStamps = (await Prompt.numberPrompt({prompt: 'How many stamps do you want?', channel, userId}))[0];
 
                 await botGuild.setUpStamps(this.client, numberOfStamps);
+                guild.setGroupEnabled('stamps', true);
                 discordServices.sendMsgToChannel(channel, userId, 'The stamp roles have been created, you can change their name and/or color, but their stamp number is final!', 60);
             } else {
                 discordServices.sendMsgToChannel(channel, userId, 'The stamp functionality was not set up.', 10);

--- a/commands/stamps/change-stamp-time.js
+++ b/commands/stamps/change-stamp-time.js
@@ -8,7 +8,7 @@ module.exports = class ChangeStampTime extends PermissionCommand {
     constructor(client) {
         super(client, {
             name: 'change-stamp-time',
-            group: 'a_utility',
+            group: 'stamps',
             memberName: 'new stamp time',
             description: 'Will set the given seconds as the new stamp time for activities.',
             guildOnly: true,

--- a/commands/stamps/distribute-stamp.js
+++ b/commands/stamps/distribute-stamp.js
@@ -7,7 +7,7 @@ module.exports = class DistributeStamp extends PermissionCommand {
     constructor(client) {
         super(client, {
             name: 'distribute-stamp',
-            group: 'a_activity',
+            group: 'stamps',
             memberName: 'gives stamps',
             description: 'gives a stamp to everyone who reacted within the time-frame, if targetChannelKey not give, it will send it to the message channel.',
             args: [

--- a/commands/stamps/password-stamp.js
+++ b/commands/stamps/password-stamp.js
@@ -9,7 +9,7 @@ module.exports = class PasswordStamp extends PermissionCommand {
     constructor(client) {
         super(client, {
             name: 'password-stamp',
-            group: 'a_activity',
+            group: 'stamps',
             memberName: 'gives stamps requiring passwords',
             description: 'gives a stamp to everyone who reacted and gave the correct password',
             args: [

--- a/commands/stamps/raffle.js
+++ b/commands/stamps/raffle.js
@@ -13,7 +13,7 @@ module.exports = class Raffle extends PermissionCommand {
     constructor(client) {
         super(client, {
             name: 'raffle',
-            group: 'a_utility',
+            group: 'stamps',
             memberName: 'draw raffle winners',
             description: 'parses each hacker for their stamps and draws winners from them, one entry per stamp',
             guildOnly: true,

--- a/db/mongo/BotGuild.d.ts
+++ b/db/mongo/BotGuild.d.ts
@@ -59,6 +59,11 @@ interface BotGuild extends Document {
         announcementChannelID: String,
     },
 
+    ask: {
+        /** @required */
+        isEnabled: Boolean,
+    },
+
     /**
      * This is some text
      */

--- a/db/mongo/BotGuild.js
+++ b/db/mongo/BotGuild.js
@@ -102,6 +102,13 @@ const BotGuildSchema = new Schema({
         },
     },
 
+    ask: {
+        isEnabled: {
+            type: Boolean,
+            default: false,
+        },
+    },
+
     blackList: {
         type: Map,
         default: new Map(),

--- a/index.js
+++ b/index.js
@@ -86,19 +86,20 @@ bot.once('ready', async () => {
     mainLogger.warning(`Connected to mongoose successfully!`, { event: "Ready Event" });
 
     // make sure all guilds have a botGuild, this is in case the bot goes offline and its added
-    // to a guild.
+    // to a guild. If botGuild is found, make sure only the correct commands are enabled.
     bot.guilds.cache.forEach(async (guild, key, guilds) => {
         let botGuild = await BotGuild.findById(guild.id);
         if (!botGuild) {
             newGuild(guild);
             mainLogger.verbose(`Created a new botGuild for the guild ${guild.id} - ${guild.name} on bot ready.`, { event: "Ready Event" });
         } else {
-            if (!botGuild.isSetUpComplete) {
-                // set all non guarded commands to not enabled for the new guild
-                bot.registry.groups.forEach((group, key, map) => {
-                    if (!group.guarded) guild.setGroupEnabled(group, false);
-                });
-            }
+            // set all non guarded commands to not enabled for the guild
+            bot.registry.groups.forEach((group, key, map) => {
+                if (!group.guarded) guild.setGroupEnabled(group, false);
+            });
+
+            botGuild.setCommandStatus(bot);
+            
             mainLogger.verbose(`Found a botGuild for ${guild.id} - ${guild.name} on bot ready.`, { event: "Ready Event" });
         }
 

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ bot.registry
     .registerGroup('a_utility', 'utility commands for admins')
     .registerGroup('utility', 'utility commands for users')
     .registerGroup('verification', 'verification commands')
+    .registerGroup('stamps', 'stamp related commands')
     .registerGroup('essentials', 'essential commands for any guild', true)
     .registerDefaultGroups()
     .registerDefaultCommands({
@@ -92,9 +93,9 @@ bot.once('ready', async () => {
             BotGuild.create({
                 _id: guild.id,
             });
-            mainLogger.verbose(`Created a new botGuild for the guild ${guild.id} - ${guild.name} on bot ready.`, { event: "Ready Event "});
+            mainLogger.verbose(`Created a new botGuild for the guild ${guild.id} - ${guild.name} on bot ready.`, { event: "Ready Event" });
         } else {
-            mainLogger.verbose(`Found a botGuild for ${guild.id} - ${guild.name} on bot ready.`, { event: "Ready Event "});
+            mainLogger.verbose(`Found a botGuild for ${guild.id} - ${guild.name} on bot ready.`, { event: "Ready Event" });
         }
 
         // create the logger for the guild


### PR DESCRIPTION
Closes #118.

Moved all the stamp commands to their own group called stamps. This group is only enabled when the stamps are enabled during bot-init command. 

Also realsed when bot restart, command enable/disabled status is restarted. When bot is ready it runs through the guilds and disables commands for any guilds that are not set up.